### PR TITLE
Adding links to create content to home page - closes #106

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,0 +1,5 @@
+class WelcomeController < ApplicationController
+  def index
+    @curation_concerns = CurationConcerns::ClassifyConcern.new.all_curation_concern_classes
+  end
+end

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,0 +1,31 @@
+<br />
+<p>
+  <%=t('curation_concerns.product_name') %> is a secure repository service enabling the
+  <%=t('curation_concerns.institution.name') %> community to share its research and scholarly
+  work with a worldwide audience. Faculty, staff, and students can use
+  <%=t('curation_concerns.product_name') %> to collect their work in one location and create a
+  durable and citeable record of their papers, presentations, publications, data
+  sets, or other scholarly creations.
+</p>
+
+<div class="row">
+  <ul class="classify-work">
+    <% @curation_concerns.each do |klass| %>
+      <% if can? :create, klass %>
+        <li class="work-type">
+          <h3 class="title"><%= klass.human_readable_type %></h3>
+          <p class="short-description" id="<%= dom_class(klass, 'short_description') %>">
+            <%= klass.human_readable_short_description %>
+          </p>
+          <%= link_to 'Add New',
+            main_app.new_polymorphic_path([:curation_concerns, klass]),
+            class: "add-button btn btn-primary #{dom_class(klass, 'add_new')}"
+          %>
+        </li>
+      <% end %>
+    <% end %>
+    <li class="work-type placeholder" aria-hidden="true"></li>
+    <li class="work-type placeholder" aria-hidden="true"></li>
+    <li class="work-type placeholder" aria-hidden="true"></li>
+  </ul>
+</div>

--- a/spec/features/root_spec.rb
+++ b/spec/features/root_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.feature 'Home Page', type: :feature do
+  describe 'a logged in user' do
+    let(:user) { FactoryGirl.create(:scanned_book_creator) }
+
+    before(:each) do
+      sign_in user
+    end
+
+    scenario 'Logged in users see welcome text and links to create content' do
+      visit root_path
+      expect(page).to have_content('Plum: A Repository is a secure repository service')
+      expect(page).to have_selector('li.work-type/h3.title', text: 'Scanned Book')
+    end
+  end
+
+  describe 'an anonymous user' do
+    scenario 'Anonymous users see only welcome text' do
+      visit root_path
+      expect(page).to have_content('Plum: A Repository is a secure repository service')
+      expect(page).not_to have_selector('li.work-type/h3.title', text: 'Scanned Book')
+    end
+  end
+end


### PR DESCRIPTION
* Updating welcome view instead of changing routes to preserve view for anonymous users (`classify_concerns#new` requires auth)