### PR TITLE
Fix login link on show views

### DIFF
--- a/app/views/shared/_site_actions.html.erb
+++ b/app/views/shared/_site_actions.html.erb
@@ -2,5 +2,5 @@
   <%= render 'shared/add_content' %>
   <%= render 'shared/my_actions' %>
 <% else %>
-  <%= link_to 'Log In', user_omniauth_authorize_path(:cas), class: 'btn btn-primary login', role: 'menuitem' %>
+  <%= link_to 'Log In', main_app.user_omniauth_authorize_path(:cas), class: 'btn btn-primary login', role: 'menuitem' %>
 <% end %>


### PR DESCRIPTION
The context was in the engine, so it needed to know where the routes were from.