### PR TITLE
Fix role management link

### DIFF
--- a/app/views/shared/_add_works.html.erb
+++ b/app/views/shared/_add_works.html.erb
@@ -10,7 +10,7 @@
               </li>
             <% end %>
             <% if can? :create, Role %>
-              <li><%= link_to 'Manage Roles', role_management.roles_path, class: 'item-option link-to-full-list', role: 'menuitem' %></li>
+              <li><%= link_to 'Manage Roles', role_management.roles_path, class: 'item-option', role: 'menuitem' %></li>
             <% end %>
             <li><%= link_to 'More Options', curation_concerns.new_classify_concern_path, class: 'item-option link-to-full-list', role: 'menuitem' %></li>
           </ul>


### PR DESCRIPTION
It had a bad class which was making it styled as italics.