### PR TITLE
Add Browse Everything for Server Uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ noid-minter-state
 /jetty
 /fits
 /coverage
+/staged_files

--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,4 @@ gem 'sidekiq'
 gem "omniauth-cas"
 gem 'ezid-client'
 gem 'sprockets-es6'
+gem 'browse-everything', github: 'projecthydra-labs/browse-everything'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,22 @@ GIT
       rdf-vocab (~> 0.8.1)
 
 GIT
+  remote: git://github.com/projecthydra-labs/browse-everything.git
+  revision: 7f547a23d8fc20bd249b8f607e009b03aa112c5d
+  specs:
+    browse-everything (0.9.1)
+      bootstrap-sass
+      dropbox-sdk (>= 1.6.2)
+      font-awesome-rails
+      google-api-client
+      google_drive
+      httparty
+      rails (>= 3.1)
+      ruby-box
+      sass-rails
+      skydrive
+
+GIT
   remote: git://github.com/projecthydra-labs/curation_concerns.git
   revision: 64527cc03b7f8c610d6aa860eed7dbb0f1c59458
   branch: master
@@ -170,6 +186,10 @@ GEM
     ast (2.1.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
+    autoparse (0.3.3)
+      addressable (>= 2.3.1)
+      extlib (>= 0.9.15)
+      multi_json (>= 1.0.0)
     autoprefixer-rails (6.1.0.1)
       execjs
       json
@@ -278,6 +298,8 @@ GEM
     docile (1.1.5)
     domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
+    dropbox-sdk (1.6.5)
+      json
     ebnf (1.0.0)
       rdf (~> 1.1)
       sxp (~> 0.1, >= 0.1.3)
@@ -285,6 +307,7 @@ GEM
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
     execjs (2.6.0)
+    extlib (0.9.16)
     ezid-client (1.1.1)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -294,17 +317,50 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
+    font-awesome-rails (4.4.0.0)
+      railties (>= 3.2, < 5.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    google-api-client (0.8.6)
+      activesupport (>= 3.2)
+      addressable (~> 2.3)
+      autoparse (~> 0.3)
+      extlib (~> 0.9)
+      faraday (~> 0.9)
+      googleauth (~> 0.3)
+      launchy (~> 2.4)
+      multi_json (~> 1.10)
+      retriable (~> 1.4)
+      signet (~> 0.6)
+    google_drive (1.0.2)
+      google-api-client (>= 0.7.0, < 0.9)
+      minitest (>= 5.1.0)
+      nokogiri (>= 1.4.4, != 1.5.2, != 1.5.1)
+      oauth (>= 0.3.6)
+      oauth2 (>= 0.5.0)
+    googleauth (0.4.2)
+      faraday (~> 0.9)
+      jwt (~> 1.4)
+      logging (~> 2.0)
+      memoist (~> 0.12)
+      multi_json (~> 1.11)
+      signet (~> 0.6)
     haml (4.0.7)
       tilt
     hashdiff (0.2.2)
     hashie (3.4.2)
     hitimes (1.2.3)
     htmlentities (4.3.4)
+    httmultiparty (0.3.16)
+      httparty (>= 0.7.3)
+      mimemagic
+      multipart-post
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     http_logger (0.5.1)
+    httparty (0.13.7)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
     hydra-access-controls (9.4.1)
       active-fedora (~> 9.0)
       activesupport (~> 4.0)
@@ -351,6 +407,7 @@ GEM
     json-ld (1.99.0)
       multi_json (~> 1.11)
       rdf (~> 1.99)
+    jwt (1.5.2)
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -383,7 +440,11 @@ GEM
       rdf-xsd (~> 1.1, >= 1.1.5)
       sparql (~> 1.99)
       sparql-client (~> 1.99)
+    little-plugger (1.1.4)
     logger (1.2.8)
+    logging (2.0.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -391,14 +452,17 @@ GEM
     marc (1.0.0)
       scrub_rb (>= 1.0.1, < 2)
       unf
+    memoist (0.12.0)
     method_source (0.8.2)
     mime-types (2.6.2)
+    mimemagic (0.3.0)
     mini_magick (4.3.6)
     mini_portile (0.6.2)
     minitest (5.8.2)
     modernizr-rails (2.7.1)
     mono_logger (1.1.0)
     multi_json (1.11.2)
+    multi_xml (0.5.5)
     multipart-post (2.0.0)
     net-http-persistent (2.9.4)
     net-scp (1.2.1)
@@ -412,6 +476,13 @@ GEM
       activesupport (>= 3.2.18)
       i18n
       nokogiri
+    oauth (0.4.7)
+    oauth2 (1.0.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (~> 1.2)
     om (3.1.0)
       activemodel
       activesupport
@@ -554,6 +625,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
+    retriable (1.4.1)
     rsolr (1.0.13)
       builder (>= 2.1.2)
     rspec-core (3.3.2)
@@ -580,6 +652,11 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
     rubocop-rspec (1.3.1)
+    ruby-box (1.15.0)
+      addressable
+      json
+      multipart-post
+      oauth2
     ruby-progressbar (1.7.5)
     rubyzip (1.1.7)
     safe_yaml (1.0.4)
@@ -600,6 +677,12 @@ GEM
       json (~> 1.0)
       redis (~> 3.2, >= 3.2.1)
       redis-namespace (~> 1.5, >= 1.5.2)
+    signet (0.6.1)
+      addressable (~> 2.3)
+      extlib (~> 0.9)
+      faraday (~> 0.9)
+      jwt (~> 1.5)
+      multi_json (~> 1.10)
     simple_form (3.1.1)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
@@ -612,6 +695,11 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    skydrive (1.2.0)
+      activesupport
+      httmultiparty
+      httparty (>= 0.11.0)
+      oauth2 (>= 0.9.2)
     slop (3.6.0)
     solrizer (3.3.0)
       activesupport
@@ -689,6 +777,7 @@ PLATFORMS
 DEPENDENCIES
   active-fedora!
   activefedora-aggregation!
+  browse-everything!
   capistrano-passenger
   capistrano-rails
   capistrano-rails-console

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,7 @@
 //= require jquery-ui/sortable
 // Required by Blacklight
 //= require blacklight/blacklight
+//= require browse_everything
 
 //= require_tree .
 

--- a/app/assets/javascripts/browse_everything_initialize.es6
+++ b/app/assets/javascripts/browse_everything_initialize.es6
@@ -1,0 +1,30 @@
+{
+  jQuery(() => {
+    window.server_uploader = new ServerUploader
+  })
+
+  class ServerUploader {
+    constructor() {
+      this.element = $(".browse-everything")
+      this.element.click((event) => event.preventDefault())
+      this.mount_browse_everything()
+    }
+
+    mount_browse_everything() {
+      this.element.browseEverything({
+        route: "/browse",
+        target: "#browse-everything-form"
+      }).done(this.finished_browsing)
+    }
+
+    get finished_browsing() {
+      return () => {
+        this.submit_files()
+      }
+    }
+
+    submit_files() {
+      $("#browse-everything-form").submit()
+    }
+  }
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -32,4 +32,5 @@
 
 @import "components/viewer";
 @import "components/sorting";
-@import "jquery-ui/sortable"
+@import "jquery-ui/sortable";
+@import "browse_everything";

--- a/app/controllers/curation_concerns/scanned_resources_controller.rb
+++ b/app/controllers/curation_concerns/scanned_resources_controller.rb
@@ -41,6 +41,13 @@ class CurationConcerns::ScannedResourcesController < CurationConcerns::CurationC
     end
   end
 
+  def browse_everything_files
+    upload_set_id = ActiveFedora::Noid::Service.new.mint
+    CompositePendingUpload.create(selected_files_params, curation_concern.id, upload_set_id)
+    BrowseEverythingIngestJob.perform_later(curation_concern.id, upload_set_id, current_user, selected_files_params)
+    redirect_to main_app.curation_concerns_scanned_resource_path(curation_concern)
+  end
+
   private
 
     def lock_manager
@@ -48,5 +55,9 @@ class CurationConcerns::ScannedResourcesController < CurationConcerns::CurationC
         CurationConcerns.config.lock_time_to_live,
         CurationConcerns.config.lock_retry_count,
         CurationConcerns.config.lock_retry_delay)
+    end
+
+    def selected_files_params
+      params[:selected_files]
     end
 end

--- a/app/decorators/io_decorator.rb
+++ b/app/decorators/io_decorator.rb
@@ -1,0 +1,9 @@
+class IoDecorator < Hydra::Derivatives::IoDecorator
+  def original_filename
+    original_name
+  end
+
+  def content_type
+    mime_type
+  end
+end

--- a/app/jobs/browse_everything_ingest_job.rb
+++ b/app/jobs/browse_everything_ingest_job.rb
@@ -1,0 +1,11 @@
+class BrowseEverythingIngestJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(curation_concern_id, upload_set_id, current_user, selected_files)
+    curation_concern = ActiveFedora::Base.find(curation_concern_id)
+    selected_files.each do |_index, file_info|
+      actor = ::CurationConcerns::FileSetActor.new(FileSet.new, current_user)
+      BrowseEverythingIngester.new(curation_concern, upload_set_id, actor, file_info).save
+    end
+  end
+end

--- a/app/models/composite_pending_upload.rb
+++ b/app/models/composite_pending_upload.rb
@@ -1,0 +1,35 @@
+class CompositePendingUpload
+  def self.create(params, curation_concern_id, upload_set_id)
+    params.each do |_index, file_options|
+      new(file_options, curation_concern_id, upload_set_id).save
+    end
+  end
+
+  attr_reader :url, :file_name, :file_size, :upload_set_id, :curation_concern_id
+
+  def initialize(file_options, curation_concern_id, upload_set_id)
+    @url = file_options.fetch(:url)
+    @file_name = file_options.fetch(:file_name)
+    @file_size = file_options.fetch(:file_size)
+    @upload_set_id = upload_set_id
+    @curation_concern_id = curation_concern_id
+  end
+
+  def save
+    pending_upload.file_name = file_name
+    pending_upload.file_path = file_path
+    pending_upload.upload_set_id = upload_set_id
+    pending_upload.curation_concern_id = curation_concern_id
+    pending_upload.save
+  end
+
+  private
+
+    def file_path
+      FilePath.new(url).clean
+    end
+
+    def pending_upload
+      @pending_upload ||= PendingUpload.new
+    end
+end

--- a/app/models/pending_upload.rb
+++ b/app/models/pending_upload.rb
@@ -1,0 +1,3 @@
+class PendingUpload < ActiveRecord::Base
+  validates :curation_concern_id, :upload_set_id, :file_name, :file_path, presence: true
+end

--- a/app/models/scanned_resource.rb
+++ b/app/models/scanned_resource.rb
@@ -13,4 +13,8 @@ class ScannedResource < ActiveFedora::Base
       doc[ActiveFedora::SolrQueryBuilder.solr_name("ordered_by", :symbol)] += send(:ordered_by_ids)
     end
   end
+
+  def pending_uploads
+    PendingUpload.where(curation_concern_id: id)
+  end
 end

--- a/app/presenters/scanned_resource_show_presenter.rb
+++ b/app/presenters/scanned_resource_show_presenter.rb
@@ -6,4 +6,8 @@ class ScannedResourceShowPresenter < CurationConcernsShowPresenter
   def file_set_ids
     ordered_ids
   end
+
+  def pending_uploads
+    @pending_uploads ||= PendingUpload.where(curation_concern_id: id)
+  end
 end

--- a/app/services/browse_everything_ingester.rb
+++ b/app/services/browse_everything_ingester.rb
@@ -1,0 +1,37 @@
+class BrowseEverythingIngester
+  attr_reader :curation_concern, :upload_set_id, :actor, :file_info
+  delegate :mime_type, :file_name, :file_path, to: :file_info
+  def initialize(curation_concern, upload_set_id, actor, file_info)
+    @curation_concern = curation_concern
+    @upload_set_id = upload_set_id
+    @actor = actor
+    @file_info = FileInfo.new(file_info.to_h)
+  end
+
+  def save
+    actor.create_metadata(upload_set_id, curation_concern, {})
+    delete_pending_uploads if actor.create_content(decorated_file)
+  end
+
+  private
+
+    def file
+      @file ||= File.open(downloaded_file_path)
+    end
+
+    def decorated_file
+      @decorated_file ||= IoDecorator.new(file, mime_type, file_name)
+    end
+
+    def retriever
+      @retriever ||= BrowseEverything::Retriever.new
+    end
+
+    def downloaded_file_path
+      @downloaded_file_path ||= retriever.download(file_info)
+    end
+
+    def delete_pending_uploads
+      curation_concern.pending_uploads.where(file_path: file_path.clean).destroy_all
+    end
+end

--- a/app/values/file_info.rb
+++ b/app/values/file_info.rb
@@ -1,0 +1,30 @@
+class FileInfo
+  attr_reader :file_info
+  delegate :[], :has_key?, to: :file_info
+  def initialize(file_info)
+    @file_info = file_info
+  end
+
+  def to_h
+    file_info
+  end
+
+  def file_name
+    file_info["file_name"]
+  end
+
+  def file_path
+    FilePath.new(file_info["url"])
+  end
+
+  def mime_type
+    file_info["mime_type"] || mime_type_from_extension
+  end
+
+  private
+
+    def mime_type_from_extension
+      extension = File.extname(file_path.clean).delete(".")
+      Mime::Type.lookup_by_extension(extension).to_s
+    end
+end

--- a/app/values/file_path.rb
+++ b/app/values/file_path.rb
@@ -1,0 +1,10 @@
+class FilePath
+  attr_reader :uri
+  def initialize(uri)
+    @uri = uri.to_s
+  end
+
+  def clean
+    ::URI.split(uri).compact.last
+  end
+end

--- a/app/views/curation_concerns/scanned_resources/_pending_uploads.html.erb
+++ b/app/views/curation_concerns/scanned_resources/_pending_uploads.html.erb
@@ -1,0 +1,21 @@
+      <table class="table table-striped">
+        <caption>Pending Uploads</caption>
+        <thead>
+          <tr>
+            <th>File Name</th>
+            <th>Uploaded</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% uploads.each do |pending_upload| %>
+            <tr>
+              <td>
+                <%= pending_upload.file_name %>
+              </td>
+              <td>
+                <%= pending_upload.created_at %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>

--- a/app/views/curation_concerns/scanned_resources/_server_upload.html.erb
+++ b/app/views/curation_concerns/scanned_resources/_server_upload.html.erb
@@ -1,0 +1,10 @@
+  <div class="well">
+    <%= form_tag polymorphic_path([main_app, :curation_concerns, @presenter, :browse_everything_files]), id: "browse-everything-form" do %>
+      <%= button_tag type: 'button', class: 'browse-everything btn btn-primary' do %>
+        Upload from Server
+      <% end %>
+    <% end %>
+    <% if @presenter.pending_uploads.present? %>
+      <%= render "pending_uploads", uploads: @presenter.pending_uploads %>
+    <% end %>
+  </div>

--- a/app/views/curation_concerns/scanned_resources/_show_actions.html.erb
+++ b/app/views/curation_concerns/scanned_resources/_show_actions.html.erb
@@ -1,4 +1,5 @@
 <% if collector || editor %>
+  <%= render "server_upload" %>
   <div class="form-actions">
     <% if editor %>
       <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, :curation_concerns, @presenter]), class: 'btn btn-default' %>

--- a/config/browse_everything_providers.yml
+++ b/config/browse_everything_providers.yml
@@ -1,0 +1,19 @@
+#
+# To make browse-everything aware of a provider, uncomment the info for that provider and add your API key information.
+# The file_system provider can be a path to any directory on the server where your application is running.
+#
+---
+file_system:
+  :home: <%= Rails.root.join("staged_files") %>
+# dropbox:
+#   :app_key: YOUR_DROPBOX_APP_KEY
+#   :app_secret: YOUR_DROPBOX_APP_SECRET
+# box:
+#   :client_id: YOUR_BOX_CLIENT_ID
+#   :client_secret: YOUR_BOX_CLIENT_SECRET
+# google_drive:
+#   :client_id: YOUR_GOOGLE_API_CLIENT_ID
+#   :client_secret: YOUR_GOOGLE_API_CLIENT_SECRET
+# sky_drive:
+#   :client_id: YOUR_MS_LIVE_CONNECT_CLIENT_ID
+#   :client_secret: YOUR_MS_LIVE_CONNECT_CLIENT_SECRET

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,7 +27,7 @@ set :deploy_to, '/opt/plum'
 # set :linked_files, fetch(:linked_files, []).push('config/database.yml', 'config/secrets.yml', 'config/blacklight.yml', 'config/fedora.yml', 'config/config.yml')
 
 # Default value for linked_dirs is []
-set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/derivatives', 'vendor/bundle')
+set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/derivatives', 'vendor/bundle', "staged_files")
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount BrowseEverything::Engine => '/browse'
   blacklight_for :catalog
   devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }, skip: [:passwords, :registration]
   devise_scope :user do
@@ -22,6 +23,7 @@ Rails.application.routes.draw do
   namespace :curation_concerns, path: :concern do
     get '/scanned_resources/:id/reorder', to: 'scanned_resources#reorder', as: 'scanned_resource_reorder'
     post '/scanned_resources/:id/reorder', to: 'scanned_resources#save_order'
+    post '/scanned_resources/:id/browse_everything_files', to: 'scanned_resources#browse_everything_files', as: 'scanned_resource_browse_everything_files'
   end
 
   namespace :curation_concerns, path: :concern do

--- a/db/migrate/20151112191128_create_pending_uploads.rb
+++ b/db/migrate/20151112191128_create_pending_uploads.rb
@@ -1,0 +1,10 @@
+class CreatePendingUploads < ActiveRecord::Migration
+  def change
+    create_table :pending_uploads do |t|
+      t.integer :curation_concern_id
+      t.integer :upload_set_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20151112191739_add_file_name_to_pending_uploads.rb
+++ b/db/migrate/20151112191739_add_file_name_to_pending_uploads.rb
@@ -1,0 +1,5 @@
+class AddFileNameToPendingUploads < ActiveRecord::Migration
+  def change
+    add_column :pending_uploads, :file_name, :string
+  end
+end

--- a/db/migrate/20151112191904_add_file_path_to_pending_uploads.rb
+++ b/db/migrate/20151112191904_add_file_path_to_pending_uploads.rb
@@ -1,0 +1,5 @@
+class AddFilePathToPendingUploads < ActiveRecord::Migration
+  def change
+    add_column :pending_uploads, :file_path, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151022175517) do
+ActiveRecord::Schema.define(version: 20151112191904) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -37,6 +37,15 @@ ActiveRecord::Schema.define(version: 20151022175517) do
   end
 
   add_index "checksum_audit_logs", ["file_set_id", "file_id"], name: "by_generic_file_id_and_file_id"
+
+  create_table "pending_uploads", force: :cascade do |t|
+    t.integer  "curation_concern_id"
+    t.integer  "upload_set_id"
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
+    t.string   "file_name"
+    t.string   "file_path"
+  end
 
   create_table "roles", force: :cascade do |t|
     t.string "name"

--- a/spec/factories/pending_uploads.rb
+++ b/spec/factories/pending_uploads.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :pending_upload do
+    curation_concern_id 1
+    upload_set_id 1
+    file_name "Test.tiff"
+    file_path "/Test/Path/Test.tiff"
+  end
+end

--- a/spec/models/pending_upload_spec.rb
+++ b/spec/models/pending_upload_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe PendingUpload, type: :model do
+  subject { FactoryGirl.build(:pending_upload) }
+  describe "#validations" do
+    it "has a valid factory" do
+      expect(subject).to be_valid
+    end
+    context "when curation_concern_id is blank" do
+      it "is invalid" do
+        subject.curation_concern_id = nil
+
+        expect(subject).not_to be_valid
+      end
+    end
+    context "when upload_set_id is blank" do
+      it "is invalid" do
+        subject.upload_set_id = nil
+
+        expect(subject).not_to be_valid
+      end
+    end
+    context "when file_name is blank" do
+      it "is invalid" do
+        subject.file_name = nil
+
+        expect(subject).not_to be_valid
+      end
+    end
+    context "when file_path is blank" do
+      it "is invalid" do
+        subject.file_path = nil
+
+        expect(subject).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/scanned_resource_spec.rb
+++ b/spec/models/scanned_resource_spec.rb
@@ -202,4 +202,18 @@ describe ScannedResource do
       expect(subject.identifier).to eq('1234')
     end
   end
+
+  describe "#pending_uploads" do
+    it "returns all pending uploads" do
+      subject.save
+      pending_upload = FactoryGirl.create(:pending_upload, curation_concern_id: subject.id)
+
+      expect(subject.pending_uploads).to eq [pending_upload]
+    end
+    context "when not persisted" do
+      it "returns a blank array" do
+        expect(described_class.new.pending_uploads).to eq []
+      end
+    end
+  end
 end

--- a/spec/presenters/scanned_resource_show_presenter_spec.rb
+++ b/spec/presenters/scanned_resource_show_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ScannedResourceShowPresenter do
   let(:date_created) { "2015-09-02" }
   let(:state) { "pending" }
   let(:solr_document) do
-    instance_double(SolrDocument, date_created: date_created, state: state)
+    instance_double(SolrDocument, date_created: date_created, state: state, id: "test")
   end
   let(:ability) { nil }
 
@@ -18,6 +18,13 @@ RSpec.describe ScannedResourceShowPresenter do
   describe "#state" do
     it "delegates to solr document" do
       expect(subject.state).to eq state
+    end
+  end
+
+  describe "#pending_uploads" do
+    it "finds all pending uploads" do
+      pending_upload = FactoryGirl.create(:pending_upload, curation_concern_id: solr_document.id)
+      expect(subject.pending_uploads).to eq [pending_upload]
     end
   end
 end

--- a/spec/values/file_info_spec.rb
+++ b/spec/values/file_info_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe FileInfo do
+  subject { described_class.new(file_info) }
+  let(:file_info) do
+    {
+      "url" => "file:///bla/test/1.tiff",
+      "file_name" => "1.tiff",
+      "file_size" => 100
+    }
+  end
+
+  describe "#to_h" do
+    it "returns the file info" do
+      expect(subject.to_h).to eq file_info
+    end
+  end
+
+  describe "[]" do
+    it "accesses the hash" do
+      expect(subject["file_name"]).to eq "1.tiff"
+    end
+  end
+
+  describe "#has_key?" do
+    it "delegates to the hash" do
+      expect(subject).to have_key "file_name"
+    end
+  end
+
+  describe "#file_name" do
+    it "returns the file name" do
+      expect(subject.file_name).to eq "1.tiff"
+    end
+  end
+
+  describe "#file_path" do
+    it "returns a FilePath of the path" do
+      expect(subject.file_path.uri).to eq file_info["url"]
+      expect(subject.file_path.clean).to eq "/bla/test/1.tiff"
+    end
+  end
+
+  describe "#mime_type" do
+    it "returns the mime type of the path based on extension" do
+      expect(subject.mime_type).to eq "image/tiff"
+    end
+    context "when the file_info hash provides a mime type" do
+      let(:file_info) do
+        {
+          "url" => "file:///bla/test/1.tiff",
+          "file_name" => "1.tiff",
+          "file_size" => 100,
+          "mime_type" => "image/jpeg"
+        }
+      end
+      it "uses that" do
+        expect(subject.mime_type).to eq "image/jpeg"
+      end
+    end
+  end
+end

--- a/spec/values/file_path_spec.rb
+++ b/spec/values/file_path_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe FilePath do
+  subject { described_class.new(path_uri) }
+  let(:path_uri) { "file:///bla/test/Test.tiff" }
+
+  describe "#uri" do
+    it "returns the uri" do
+      expect(subject.uri).to eq path_uri
+    end
+  end
+
+  describe "#clean" do
+    it "returns the URI without the file schema" do
+      expect(subject.clean).to eq "/bla/test/Test.tiff"
+    end
+  end
+end

--- a/spec/views/curation_concerns/scanned_resources/_show_actions.html.erb_spec.rb
+++ b/spec/views/curation_concerns/scanned_resources/_show_actions.html.erb_spec.rb
@@ -17,4 +17,19 @@ RSpec.describe "curation_concerns/scanned_resources/_show_actions.html.erb" do
   it "renders a reorder link" do
     expect(rendered).to have_link "Reorder", curation_concerns_scanned_resource_reorder_path(id: resource.id)
   end
+  it "renders a server upload form" do
+    expect(rendered).to have_selector "form#browse-everything-form"
+    expect(rendered).to have_selector "button.browse-everything"
+  end
+  context "when there are pending uploads" do
+    let(:presenter) do
+      s = ScannedResourceShowPresenter.new(solr_document, nil)
+      allow(s).to receive(:pending_uploads).and_return([pending_upload])
+      s
+    end
+    let(:pending_upload) { FactoryGirl.build(:pending_upload) }
+    it "displays them" do
+      expect(rendered).to have_content pending_upload.file_name
+    end
+  end
 end


### PR DESCRIPTION
This enables a user to upload to a server share and then select the
files they want to be added to the work from there. Files uploaded this
way maintain order and uploads happen in the background.