### PR TITLE
Add a link to parent from scanned resource

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -36,3 +36,5 @@
 @import "jquery-ui/sortable";
 @import "jquery-ui/selectable";
 @import "browse_everything";
+
+@import "components/breadcrumb";

--- a/app/assets/stylesheets/components/breadcrumb.scss
+++ b/app/assets/stylesheets/components/breadcrumb.scss
@@ -1,0 +1,8 @@
+.breadcrumb {
+  background-color: white;
+  margin-bottom: 10px;
+  border-radius: 0px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: rgb(238, 238, 238);
+}

--- a/app/assets/stylesheets/components/positioning.scss
+++ b/app/assets/stylesheets/components/positioning.scss
@@ -4,4 +4,5 @@ main {
 
 .main-header {
     margin: 0;
+    border-bottom: 0;
 }

--- a/app/helpers/multi_volume_work_helper.rb
+++ b/app/helpers/multi_volume_work_helper.rb
@@ -1,0 +1,13 @@
+module MultiVolumeWorkHelper
+  def multi_volume_work_page_header
+    h = content_tag(:h1, @presenter.title)
+    h += multi_volume_work_breadcrumb
+    h.html_safe
+  end
+
+  def multi_volume_work_breadcrumb
+    content_tag(:ul, class: 'breadcrumb') do
+      content_tag(:li, @presenter.human_readable_type, class: 'active')
+    end
+  end
+end

--- a/app/helpers/scanned_resource_helper.rb
+++ b/app/helpers/scanned_resource_helper.rb
@@ -1,0 +1,47 @@
+module ScannedResourceHelper
+  def scanned_resource_page_header
+    h = content_tag(:h1, @presenter.title)
+    h += scanned_resource_breadcrumb
+    h.html_safe
+  end
+
+  def scanned_resource_parent_id
+    return unless @presenter.solr_document
+                  .fetch('ordered_by_ssim', []).include? params[:parent_id]
+    params[:parent_id]
+  end
+
+  def scanned_resource_parent_presenter
+    return unless scanned_resource_parent_id
+    @parent_presenter ||= CurationConcerns::PresenterFactory
+                          .build_presenters([scanned_resource_parent_id],
+                                            MultiVolumeWorkShowPresenter,
+                                            @presenter.current_ability)
+    @parent_presenter.first
+  end
+
+  def scanned_resource_breadcrumb
+    content_tag(:ul, class: 'breadcrumb') do
+      concat(scanned_resource_parent_work)
+      concat(scanned_resource_work_type)
+    end
+  end
+
+  def scanned_resource_parent_work
+    return '' unless scanned_resource_parent_presenter
+    title = scanned_resource_parent_presenter.title
+    link = content_tag(:a, truncate(title),
+                       title: title,
+                       href: scanned_resource_parent_path)
+    content_tag(:li, link)
+  end
+
+  def scanned_resource_work_type
+    content_tag(:li, @presenter.human_readable_type, class: 'active')
+  end
+
+  def scanned_resource_parent_path
+    Rails.application.routes.url_helpers
+      .curation_concerns_multi_volume_work_path(scanned_resource_parent_id)
+  end
+end

--- a/app/views/curation_concerns/multi_volume_works/_members.html.erb
+++ b/app/views/curation_concerns/multi_volume_works/_members.html.erb
@@ -15,7 +15,7 @@
           <tr>
             <td class="col-xs-3"><%= render_thumbnail_tag res %></td>
             <td>
-              <%= link_to res.title, main_app.curation_concerns_scanned_resource_path(res.id) %>
+              <%= link_to res.title, main_app.curation_concerns_member_scanned_resource_path(@presenter.id, res.id) %>
             </td>
           </tr>
         <% end %>

--- a/app/views/curation_concerns/multi_volume_works/show.html.erb
+++ b/app/views/curation_concerns/multi_volume_works/show.html.erb
@@ -1,6 +1,6 @@
 <% provide :page_title, @presenter.page_title %>
 <% provide :page_header do %>
-  <h1><%= @presenter %> <span class="human_readable_type">(<%= @presenter.human_readable_type %>)</span></h1>
+  <%= multi_volume_work_page_header %>
 <% end %>
 
 <% collector = can?(:collect, @presenter.id) %>
@@ -19,4 +19,3 @@
     <% end %>
   </div>
 <% end %>
-

--- a/app/views/curation_concerns/scanned_resources/show.html.erb
+++ b/app/views/curation_concerns/scanned_resources/show.html.erb
@@ -1,0 +1,16 @@
+<% provide :page_title, @presenter.page_title %>
+<% provide :page_header do %>
+  <%= scanned_resource_page_header %>
+<% end %>
+
+<% collector = can?(:collect, @presenter.id) %>
+<% editor    = can?(:edit,    @presenter.id) %>
+
+<%= render 'representative_media', work: @presenter %>
+<%= render 'attributes', curation_concern: @presenter %>
+<%= render 'related_files', presenter: @presenter %>
+<% if editor %>
+  <%= render 'multiple_upload', presenter: @presenter %>
+<% end %>
+
+<%= render "show_actions", collector: collector, editor: editor%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,6 @@ Rails.application.routes.draw do
   end
 
   namespace :curation_concerns, path: :concern do
-    resources :scanned_resources, only: [:new, :create], path: 'container/:parent_id/scanned_resources', as: 'member_scanned_resource'
+    resources :scanned_resources, only: [:new, :create, :show], path: 'container/:parent_id/scanned_resources', as: 'member_scanned_resource'
   end
 end

--- a/spec/factories/scanned_resources.rb
+++ b/spec/factories/scanned_resources.rb
@@ -27,5 +27,14 @@ FactoryGirl.define do
 
     factory :open_scanned_resource do
     end
+
+    factory :scanned_resource_with_multi_volume_work do
+      after(:create) do |work, evaluator|
+        parent = FactoryGirl.create(:multi_volume_work, user: evaluator.user)
+        parent.ordered_members << work
+        parent.save
+        work.save
+      end
+    end
   end
 end

--- a/spec/features/edit_multi_volume_work_spec.rb
+++ b/spec/features/edit_multi_volume_work_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "MultiVolumeWorksController", type: :feature do
     choose 'Metadata Review'
 
     click_button 'Update Multi volume work'
-    expect(page).to have_text("Test title (Multi Volume Work)")
+    expect(page).to have_text("Test title")
     expect(page).to have_text("New note")
     expect(page).to have_selector("span.label-info", "Metadata Review")
   end

--- a/spec/features/edit_scanned_resource_spec.rb
+++ b/spec/features/edit_scanned_resource_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature "ScannedResourcesController", type: :feature do
   let(:user) { FactoryGirl.create(:curation_concern_creator) }
-  let(:scanned_resource) { FactoryGirl.create(:scanned_resource, user: user) }
+  let(:scanned_resource) { FactoryGirl.create(:scanned_resource_with_multi_volume_work, user: user) }
 
   context "an authorized user" do
     before(:each) do
@@ -23,7 +23,7 @@ RSpec.feature "ScannedResourcesController", type: :feature do
       choose 'Final Review'
 
       click_button 'Update Scanned resource'
-      expect(page).to have_text("Test title (Scanned Resource)")
+      expect(page).to have_text("Test title")
       expect(page).to have_selector("span.label-primary", "Final Review")
     end
 
@@ -52,6 +52,13 @@ RSpec.feature "ScannedResourcesController", type: :feature do
     scenario "User can't edit a scanned resource" do
       visit edit_polymorphic_path [scanned_resource]
       expect(page).to have_selector("div.alert-info", "You are not authorized to access this page")
+    end
+
+    scenario "User can follow link to parent multi volume work" do
+      parent_id = scanned_resource.ordered_by.first.id
+      visit curation_concerns_member_scanned_resource_path(parent_id, scanned_resource.id)
+      click_link 'Test title'
+      expect(page).to have_text('Test title')
     end
   end
 end

--- a/spec/helpers/multi_volume_work_helper_spec.rb
+++ b/spec/helpers/multi_volume_work_helper_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe MultiVolumeWorkHelper do
+  let(:solr_document) { SolrDocument.new }
+  let(:presenter) { double(solr_document: solr_document,
+                           title: 'multi volume work title',
+                           human_readable_type: 'Multi Volume Work') }
+  before do
+    assign(:presenter, presenter)
+  end
+
+  describe '#multi_volume_work_page_header' do
+    subject { helper.multi_volume_work_page_header }
+
+    it { is_expected.to have_content('multi volume work title') }
+    it { is_expected.to have_content('Multi Volume Work') }
+    it { is_expected.to have_selector('ul.breadcrumb') }
+  end
+end

--- a/spec/helpers/scanned_resource_helper_spec.rb
+++ b/spec/helpers/scanned_resource_helper_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+describe ScannedResourceHelper do
+  let(:current_ability) { nil }
+  let(:solr_document) { SolrDocument.new(ordered_by_ssim: ['testid']) }
+  let(:results) { [{ id: 'testid', title_tesim: 'multi volume work title' }] }
+  let(:presenter) { double(solr_document: solr_document,
+                           current_ability: current_ability,
+                           title: 'scanned resource title',
+                           human_readable_type: 'Scanned Resource') }
+  before do
+    assign(:presenter, presenter)
+
+    # method stub for solr query in presenter factory
+    allow(ActiveFedora::SolrService.instance.conn).to receive(:post)
+      .with('select', data: { q: "{!terms f=id}testid", rows: 1000, qt: 'standard' })
+      .and_return('response' => { 'docs' => results })
+  end
+
+  before(:each) do
+    allow(helper).to receive(:params).and_return(parent_id: parent_id)
+  end
+
+  describe '#scanned_resource_parent_id' do
+    subject { helper.scanned_resource_parent_id }
+
+    context 'without parent_id param in resource ordered_by array' do
+      let(:parent_id) { 'bogustestid' }
+      it { is_expected.to be_nil }
+    end
+
+    context 'with parent_id param in resource ordered_by array' do
+      let(:parent_id) { 'testid' }
+      it { is_expected.to eq 'testid' }
+    end
+  end
+
+  describe '#scanned_resource_parent_presenter' do
+    subject { helper.scanned_resource_parent_presenter }
+
+    context 'without valid parent id' do
+      let(:parent_id) { 'bogustestid' }
+      it { is_expected.to be_nil }
+    end
+
+    context 'with valid parent id' do
+      let(:parent_id) { 'testid' }
+      it { is_expected.to be_a_kind_of MultiVolumeWorkShowPresenter }
+    end
+  end
+
+  describe '#scanned_resource_page_header' do
+    subject { helper.scanned_resource_page_header }
+
+    context 'without valid parent id' do
+      let(:parent_id) { 'bogustestid' }
+
+      it { is_expected.to have_content('scanned resource title') }
+      it { is_expected.to have_content('Scanned Resource') }
+      it { is_expected.to have_selector('ul.breadcrumb') }
+      it { is_expected.not_to have_link('multi volume work title') }
+    end
+
+    context 'with valid parent id' do
+      let(:parent_id) { 'testid' }
+      let(:href) { Rails.application.routes.url_helpers
+        .curation_concerns_multi_volume_work_path(parent_id) }
+
+      it { is_expected.to have_content('scanned resource title') }
+      it { is_expected.to have_content('Scanned Resource') }
+      it { is_expected.to have_selector('ul.breadcrumb') }
+      it { is_expected.to have_link('multi volume work title', href: href) }
+    end
+  end
+end


### PR DESCRIPTION
Adds a breadcrumb on a scanned resource that leads back to the parent multivolume work. Looks good with short work titles, but what happens when one or both have longer titles? 

<img width="948" alt="screenshot 2015-12-08 11 08 04" src="https://cloud.githubusercontent.com/assets/784196/11660711/74a138e0-9d9c-11e5-9d86-0f18116882f4.png">
