### PR TITLE
Structural Metadata Editor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ group :development, :test do
   gem 'jettywrapper'
   gem "factory_girl_rails"
   gem 'jasmine-rails'
+  gem 'jasmine-jquery-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,10 @@ GIT
 
 GIT
   remote: git://github.com/projecthydra-labs/activefedora-aggregation.git
-  revision: 00d46792af0fa887da59dd9581f3ecf6b5b822e6
+  revision: f953afb564ef922c5b4cc08245c96feca101bd8d
   branch: master
   specs:
-    activefedora-aggregation (0.6.0)
+    activefedora-aggregation (0.7.0)
       active-fedora (~> 9.5)
       activesupport
       rdf (~> 1.1, >= 1.1.17.1)
@@ -393,6 +393,7 @@ GEM
       cancan
     i18n (0.7.0)
     jasmine-core (2.3.4)
+    jasmine-jquery-rails (2.0.3)
     jasmine-rails (0.12.2)
       jasmine-core (>= 1.3, < 3.0)
       phantomjs (>= 1.9)
@@ -811,6 +812,7 @@ DEPENDENCIES
   hydra-role-management (= 0.1.0)
   hydra-works!
   iiif-presentation!
+  jasmine-jquery-rails
   jasmine-rails
   jbuilder (~> 2.0)
   jettywrapper

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,6 +18,7 @@
 // Required by Blacklight
 //= require blacklight/blacklight
 //= require browse_everything
+//= require nestedSortable/jquery.mjs.nestedSortable
 
 //= require_tree .
 

--- a/app/assets/javascripts/structure_editor.es6
+++ b/app/assets/javascripts/structure_editor.es6
@@ -1,0 +1,64 @@
+jQuery(() => {
+  $(".sortable").nestedSortable({
+    handle: "div",
+    items: "li",
+    toleranceElement: "> div",
+    listType: "ul",
+    placeholder: "placeholder",
+    isAllowed: function(placeholder, placeholderParent) {
+      if($(placeholderParent).attr("data-proxy")) {
+        return false
+      } else {
+        return true
+      }
+    }
+  })
+  $(".sortable").on("click", "*[data-action=remove-list]", function(event) {
+    event.preventDefault()
+    let parent_li = $(this).parents("li").first()
+    let child_items = parent_li.find("li")
+    parent_li.before(child_items)
+    parent_li.remove()
+  })
+  $("*[data-action=submit-list]").click(function(event) {
+    event.preventDefault()
+    let element = $(".sortable")
+    let serializer = new window.StructureParser(element)
+    let url = `/concern/scanned_resources/${element.attr("data-id")}/structure`
+    let button = $(this)
+    button.text("Saving..")
+    button.addClass("disabled")
+    $.ajax({
+      type: "POST",
+      url: url,
+      data: JSON.stringify(serializer.serialize),
+      dataType: "json",
+      contentType: "application/json"
+    }).always(() => {
+      button.text("Save")
+      button.removeClass("disabled")
+    })
+  })
+  $("*[data-action=add-to-list]").click(function(event) {
+    event.preventDefault()
+    let top_element = $(".sortable")
+    let new_element = $("<li>").append(
+      $("<div>").append(
+        $("<div>", { class: "panel panel-default" }).append(
+          $("<div>", { class: "panel-heading" }).append(
+            $("<div>", { class: "title" }).append(
+              $("<input>", { type: "text", name: "label", id: "label" })
+            )
+          ).append(
+            $("<div>", { class: "toolbar" }).append(
+              $("<a>", { href: "", "data-action": "remove-list", title: "Remove "}).append(
+                $("<span>", { class: "glyphicon glyphicon-remove" })
+              )
+            )
+          )
+        )
+      )
+    )
+    top_element.append(new_element)
+  })
+})

--- a/app/assets/javascripts/structure_parser.es6
+++ b/app/assets/javascripts/structure_parser.es6
@@ -1,0 +1,62 @@
+/* exported StructureParser */
+class StructureParser {
+  constructor(element) {
+    this.element = element
+  }
+  
+  get serialize() {
+    let start_obj = {}
+    let nodes = []
+    let children = $("> li", this.element)
+    children.each((index, child) => {
+      let node = new StructureNode($(child))
+      nodes.push(node.serialize)
+    })
+    if(nodes.length > 0) {
+      start_obj["nodes"] = nodes
+    }
+    return start_obj
+  }
+}
+
+class StructureNode {
+  constructor(element) {
+    this.element = element
+  }
+
+  get serialize() {
+    let new_obj = {}
+    if(this.proxy) {
+      new_obj["proxy"] = this.proxy
+    }
+    if(this.label) {
+      new_obj["label"] = this.label
+    }
+    if(this.child_nodes.length > 0) {
+      let nodes = []
+      this.child_nodes.each((index, child) => {
+        let node = new StructureParser($(child))
+        for(let n of node.serialize["nodes"]) {
+          nodes.push(n)
+        }
+      })
+      new_obj["nodes"] = nodes
+    }
+    return new_obj
+  }
+
+  get proxy() {
+    return this.element.attr("data-proxy")
+  }
+
+  get child_nodes() {
+    return $("> ul", this.element)
+  }
+
+  get label() {
+    let input_element = $("> div input", this.element)
+    if(input_element.length > 0) {
+      return input_element.val()
+    }
+  }
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -29,6 +29,7 @@
 @import 'components/footer';
 @import 'components/header';
 @import 'components/positioning';
+@import 'components/structure_editor';
 
 @import "components/viewer";
 @import "components/sorting";

--- a/app/assets/stylesheets/components/structure_editor.scss
+++ b/app/assets/stylesheets/components/structure_editor.scss
@@ -1,0 +1,8 @@
+.sortable {
+  .placeholder {
+    outline: 1px dashed #4183C4;
+  }
+}
+#list-toolbar {
+  margin-bottom: 10px;
+}

--- a/app/controllers/curation_concerns/scanned_resources_controller.rb
+++ b/app/controllers/curation_concerns/scanned_resources_controller.rb
@@ -48,6 +48,17 @@ class CurationConcerns::ScannedResourcesController < CurationConcerns::CurationC
     @members = presenter.file_presenters
   end
 
+  def structure
+    @members = presenter.file_presenters
+    @logical_order = presenter.logical_order_object
+  end
+
+  def save_structure
+    curation_concern.logical_order.order = { "nodes": params["nodes"] }
+    curation_concern.save
+    head 200
+  end
+
   private
 
     def lock_manager

--- a/app/decorators/with_proxy_for_object.rb
+++ b/app/decorators/with_proxy_for_object.rb
@@ -1,0 +1,50 @@
+class WithProxyForObject < SimpleDelegator
+  attr_reader :members
+  def initialize(logical_order, members)
+    @members = members
+    super logical_order
+  end
+
+  def proxy_for_object
+    @proxy_for_object ||= members.find { |x| x.id == proxy_for_id }
+  end
+
+  def label
+    super || proxy_for_object.to_s
+  end
+
+  def unstructured_objects
+    @unstructured_objects ||=
+      begin
+        unstructured_proxies = (members - all_nodes).map { |x| { "proxy": x.id } }
+        node_class.new("nodes": unstructured_proxies)
+      end
+  end
+
+  private
+
+    def all_nodes
+      @all_nodes ||= enum_for(:each_node).to_a
+    end
+
+    def each_node(&block)
+      nodes.each do |node|
+        yield node.proxy_for_object if node.proxy_for_object
+        node.send(:each_node, &block)
+      end
+    end
+
+    class Factory
+      attr_reader :members
+      def initialize(members)
+        @members = members
+      end
+
+      def new(order_hash = {}, rdf_subject = nil, node_class = nil)
+        ::WithProxyForObject.new(
+          LogicalOrder.new(order_hash, rdf_subject, node_class || self),
+          members
+        )
+      end
+    end
+end

--- a/app/models/logical_order_base.rb
+++ b/app/models/logical_order_base.rb
@@ -1,0 +1,47 @@
+class LogicalOrderBase < ActiveFedora::Base
+  property :nodes, predicate: ::RDF::Vocab::DC.hasPart
+  property :head, predicate: ::RDF::Vocab::IANA['first'], multiple: false
+  property :tail, predicate: ::RDF::Vocab::IANA.last, multiple: false
+
+  def order=(order)
+    nodes_will_change!
+    head_will_change!
+    tail_will_change!
+    order = LogicalOrder.new((order), ::RDF::URI(rdf_subject))
+    graph = order.to_graph
+    # Delete old statements
+    subj = resource.subjects.to_a.select { |x| x.to_s.split("/").last.to_s.include?("#g") }
+    subj.each do |s|
+      resource.delete [s, nil, nil]
+    end
+    self.head = nil
+    self.tail = nil
+    resource << graph
+    # Set nodes so that hash URIs get persisted to Fedora.
+    self.nodes = graph.subjects.select { |x| x != rdf_subject }
+    @order = nil
+    order
+  end
+
+  def order
+    @order ||= LogicalOrderGraph.new(resource, rdf_subject).to_h
+  end
+
+  # Not useful and slows down indexing.
+  def create_date
+    nil
+  end
+
+  # Not useful, slows down indexing.
+  def modified_date
+    nil
+  end
+
+  # Serializing head/tail/nodes slows things down CONSIDERABLY, and is not
+  # useful.
+  # @note This method is used by ActiveFedora::Base upstream for indexing,
+  #   at https://github.com/projecthydra/active_fedora/blob/master/lib/active_fedora/profile_indexing_service.rb.
+  def serializable_hash(_options = nil)
+    {}
+  end
+end

--- a/app/models/scanned_resource.rb
+++ b/app/models/scanned_resource.rb
@@ -7,10 +7,13 @@ class ScannedResource < ActiveFedora::Base
   include ::NoidBehaviors
   include ::GeneratesPdfs
 
+  contains :logical_order, class_name: "LogicalOrderBase"
+
   def to_solr(solr_doc = {})
     super.tap do |doc|
       doc[ActiveFedora::SolrQueryBuilder.solr_name("ordered_by", :symbol)] ||= []
       doc[ActiveFedora::SolrQueryBuilder.solr_name("ordered_by", :symbol)] += send(:ordered_by_ids)
+      doc[ActiveFedora::SolrQueryBuilder.solr_name("logical_order", :symbol)] = [logical_order.order.to_json]
     end
   end
 

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -2,7 +2,7 @@ class SearchBuilder < CurationConcerns::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
 
   def self.show_actions
-    [:show, :manifest, :bulk_edit]
+    [:show, :manifest, :bulk_edit, :structure]
   end
 
   def hide_parented_resources(solr_params)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -48,4 +48,13 @@ class SolrDocument
   def workflow_note
     self[Solrizer.solr_name('workflow_note')]
   end
+
+  def logical_order
+    @logical_order ||=
+      begin
+        JSON.parse(self[Solrizer.solr_name("logical_order", :symbol)].first)
+      rescue
+        {}
+      end
+  end
 end

--- a/app/presenters/curation_concerns_show_presenter.rb
+++ b/app/presenters/curation_concerns_show_presenter.rb
@@ -1,7 +1,18 @@
 class CurationConcernsShowPresenter < CurationConcerns::WorkShowPresenter
-  delegate :date_created, :viewing_hint, :viewing_direction, :state, :type, :identifier, :workflow_note, to: :solr_document
+  delegate :date_created, :viewing_hint, :viewing_direction, :state, :type, :identifier, :workflow_note, :logical_order, :logical_order_object, to: :solr_document
 
   def state_badge
     StateBadge.new(type, state).render
   end
+
+  def logical_order_object
+    @logical_order_object ||=
+      logical_order_factory.new(logical_order, nil, logical_order_factory)
+  end
+
+  private
+
+    def logical_order_factory
+      @logical_order_factory ||= WithProxyForObject::Factory.new(file_presenters)
+    end
 end

--- a/app/services/canvas_builder.rb
+++ b/app/services/canvas_builder.rb
@@ -11,6 +11,10 @@ class CanvasBuilder
     @canvas ||= Canvas.new
   end
 
+  def path
+    CanvasID.new(record.id, parent_path).to_s
+  end
+
   class Canvas < IIIF::Presentation::Canvas
     def legal_viewing_hint_values
       super + ['facing-pages']
@@ -39,9 +43,5 @@ class CanvasBuilder
       canvas.images << annotation
       canvas.width = image.width
       canvas.height = image.height
-    end
-
-    def path
-      parent_path + "/canvas/#{record.id}"
     end
 end

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -84,6 +84,7 @@ class ManifestBuilder
       end
       apply_canvases unless light
       apply_manifests if manifests.length > 0
+      apply_structures
     end
 
     def apply_canvases
@@ -97,5 +98,13 @@ class ManifestBuilder
 
     def apply_manifests
       manifest['manifests'] = manifests
+    end
+
+    def apply_structures
+      manifest['structures'] = [RangeBuilder.new(logical_order, path, top: true, label: "Logical").to_h]
+    end
+
+    def logical_order
+      @logical_order ||= LogicalOrder.new(record.logical_order)
     end
 end

--- a/app/services/range_builder.rb
+++ b/app/services/range_builder.rb
@@ -1,0 +1,55 @@
+class RangeBuilder
+  attr_reader :node, :parent_path, :top
+  def initialize(node, parent_path, top: false, label: nil)
+    @node = node
+    @parent_path = parent_path
+    @top = top
+    @label = label
+  end
+
+  def label
+    @label || node.label
+  end
+
+  def to_h
+    build_range
+  end
+
+  private
+
+    def build_range
+      range = IIIF::Presentation::Range.new
+      range.label = label
+      range['@id'] = path
+      range.viewing_hint = "top" if top
+      unless regular_nodes.empty?
+        range['ranges'] = nodes.map { |x| self.class.new(x, parent_path).to_h }
+      end
+      unless proxy_nodes.empty?
+        range['canvases'] = proxy_nodes.map do |proxy_node|
+          canvas_id(proxy_node.proxy_for_id)
+        end
+      end
+      range
+    end
+
+    def nodes
+      node.nodes
+    end
+
+    def path
+      "#{parent_path}/range/#{node.id.delete('#')}"
+    end
+
+    def proxy_nodes
+      @proxy_nodes ||= nodes.select { |x| x.proxy_for.present? }
+    end
+
+    def regular_nodes
+      @regular_nodes ||= nodes.select { |x| !x.proxy_for.present? }
+    end
+
+    def canvas_id(id)
+      CanvasID.new(id, parent_path).to_s
+    end
+end

--- a/app/values/canvas_id.rb
+++ b/app/values/canvas_id.rb
@@ -1,0 +1,11 @@
+class CanvasID
+  attr_reader :id, :parent_path
+  def initialize(id, parent_path)
+    @id = id
+    @parent_path = parent_path
+  end
+
+  def to_s
+    "#{parent_path}/canvas/#{id}"
+  end
+end

--- a/app/values/logical_order.rb
+++ b/app/values/logical_order.rb
@@ -1,0 +1,79 @@
+##
+# Object responsible for iterating over a params representation of a logical
+# order.
+class LogicalOrder
+  attr_reader :order_hash, :node_class
+  attr_accessor :rdf_subject
+  # @param [Hash] order_hash The params representation of the order.
+  # @param [RDF::URI] rdf_subject The subject of the head node
+  # @param [#new] node_class The factory to generate child nodes.
+  # @example
+  #   LogicalOrder.new({"nodes": [ { "proxy": "a" } ]},
+  #     RDF::URI("http://test.com"), LogicalOrder)
+  def initialize(order_hash = {}, rdf_subject = nil, node_class = LogicalOrder)
+    @order_hash = order_hash.with_indifferent_access
+    @rdf_subject = RDF::URI(rdf_subject.to_s) if rdf_subject
+    @node_class = node_class
+  end
+
+  # @return [Array<node_class>] Child nodes of this resource.
+  def nodes
+    @nodes ||= order_hash.fetch("nodes", []).map do |values|
+      node_class.new(values)
+    end
+  end
+
+  # @return [String] Label of the top level node.
+  def label
+    order_hash.fetch("label", nil)
+  end
+
+  # @return [::RDF::Graph] Ordered graph representation of the given ordered
+  #   hash.
+  def to_graph
+    self_graph = ordered_list.to_graph
+    self_graph << [rdf_subject, RDF::Vocab::RDFS.label, label] if label
+    nodes.each do |node|
+      self_graph << node.to_graph
+    end
+    if nodes.length > 0
+      self_graph << [rdf_subject, RDF::Vocab::IANA.first, nodes.first.rdf_subject]
+      self_graph << [rdf_subject, RDF::Vocab::IANA.last, nodes.last.rdf_subject]
+    end
+    self_graph
+  end
+
+  # @return [String] ID of this node.
+  def id
+    rdf_subject.to_s if rdf_subject.to_s.start_with?("#")
+  end
+
+  # @return [RDF::URI] URI of the resource this node is a proxy for.
+  def proxy_for
+    ActiveFedora::Base.id_to_uri(order_hash["proxy"]) if proxy_for_id
+  end
+
+  # @return [String] ID of the resource this node is a proxy for.
+  def proxy_for_id
+    order_hash["proxy"]
+  end
+
+  # @return [::RDF::URI] URI of this node.
+  def rdf_subject
+    @rdf_subject ||= ordered_list.send(:new_node_subject)
+  end
+
+  private
+
+    def ordered_list
+      @ordered_list ||=
+        begin
+          o = ActiveFedora::Orders::OrderedList.new(::RDF::Graph.new, nil, nil)
+          nodes.each do |node|
+            o.insert_proxy_for_at(o.length, node.proxy_for)
+            node.rdf_subject = o.last.rdf_subject
+          end
+          o
+        end
+    end
+end

--- a/app/values/logical_order_graph.rb
+++ b/app/values/logical_order_graph.rb
@@ -1,0 +1,57 @@
+##
+# Primarily responsible for going from an ordered graph to a params
+#   representation of an order.
+class LogicalOrderGraph
+  attr_reader :graph, :head_subject
+  # @param [::RDF::Enumerable] graph Graph to parse.
+  # @param [::RDF::URI] head_subject The subject of the top node in the ordered
+  #   list.
+  def initialize(graph, head_subject)
+    @graph = graph
+    @head_subject = head_subject
+  end
+
+  # @return [Hash] The params representation of an order.
+  def to_h
+    hsh = {}
+    hsh["label"] = label if label.present? && label.to_s != head_subject.to_s
+    hsh["nodes"] = nodes.map(&:to_h) unless nodes.empty?
+    hsh["proxy"] = proxy_for_id if proxy_for_id
+    hsh.with_indifferent_access
+  end
+
+  # @return [Array<LogicalOrderGraph>] Child nodes of this resource.
+  def nodes
+    ordered_list.map do |x|
+      LogicalOrderGraph.new(graph, x.rdf_subject)
+    end
+  end
+
+  # @return [String] Label of the top level node.
+  def label
+    node.rdf_label.first
+  end
+
+  # @return [String] ID of the resource this node is a proxy for.
+  def proxy_for_id
+    ActiveFedora::Base.uri_to_id(node.proxy_for.first) if node.proxy_for.first
+  end
+
+  private
+
+    def node
+      @node ||= Node.new(head_subject) << graph
+    end
+
+    def ordered_list
+      @ordered_list ||= ActiveFedora::Orders::OrderedList.new(graph, node.first_ordered.first, node.last_ordered.first)
+    end
+
+    class Node < ActiveTriples::Resource
+      property :prev, predicate: ::RDF::Vocab::IANA.prev, cast: false
+      property :next, predicate: ::RDF::Vocab::IANA.next, cast: false
+      property :first_ordered, predicate: ::RDF::Vocab::IANA.first, cast: false
+      property :last_ordered, predicate: ::RDF::Vocab::IANA.last, cast: false
+      property :proxy_for, predicate: ::RDF::Vocab::ORE.proxyFor, cast: false
+    end
+end

--- a/app/views/curation_concerns/scanned_resources/_show_actions.html.erb
+++ b/app/views/curation_concerns/scanned_resources/_show_actions.html.erb
@@ -4,6 +4,7 @@
     <% if editor %>
       <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]), class: 'btn btn-default' %>
       <%= link_to "Bulk Edit", polymorphic_path([main_app, :bulk_edit, @presenter]), class: 'btn btn-default' %>
+      <%= link_to "Edit Structure", polymorphic_path([main_app, :structure, @presenter]), class: 'btn btn-default' %>
       <%= link_to "Attach a File", main_app.new_curation_concerns_file_set_path(@presenter), class: 'btn btn-default' %>
       <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
     <% end %>

--- a/app/views/curation_concerns/scanned_resources/_structure_node.html.erb
+++ b/app/views/curation_concerns/scanned_resources/_structure_node.html.erb
@@ -1,0 +1,28 @@
+<%= content_tag "li", data: { id: node.id, proxy: node.proxy_for_id }.compact do %>
+  <div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <div class="title">
+          <% if !node.proxy_for_object %>
+            <%= text_field_tag "label", node.label %>
+          <% else %>
+            <%= node.proxy_for_object || node.label %>
+          <% end %>
+        </div>
+        <div class="toolbar">
+          <% if !node.proxy_for_object %>
+            <a href="" title="Remove" data-action="remove-list"><span class="glyphicon glyphicon-remove"></span></a>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+  <% if node.nodes.length > 0 %>
+    <ul>
+      <% node.nodes.each do |order| %>
+        <%= render "structure_node", node: order %>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>
+</li>

--- a/app/views/curation_concerns/scanned_resources/structure.html.erb
+++ b/app/views/curation_concerns/scanned_resources/structure.html.erb
@@ -1,0 +1,18 @@
+<div id="list-toolbar">
+  <%= link_to "Back to Parent", polymorphic_path([main_app, @presenter]) %>
+  <a href="" data-action="add-to-list">
+    <button class="btn btn-default">
+      <span class="glyphicon glyphicon-plus"></span>
+      Add a Section
+    </button>
+  </a>
+  <button data-action="submit-list" class="btn btn-primary">Save</button>
+</div>
+<ul class="sortable" data-id="<%= @presenter.id %>">
+  <% @logical_order.nodes.each do |node| %>
+    <%= render "structure_node", node: node %>
+  <% end %>
+  <% @logical_order.unstructured_objects.nodes.each do |node| %>
+    <%= render "structure_node", node: node %>
+  <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
       member do
         get :bulk_edit
         get :pdf
+        get :structure
+        post :structure, action: :save_structure
         get :manifest, defaults: { format: :json }
         post :reorder, action: :save_order
         post :browse_everything_files

--- a/spec/controllers/curation_concerns/scanned_resources_controller_spec.rb
+++ b/spec/controllers/curation_concerns/scanned_resources_controller_spec.rb
@@ -256,4 +256,70 @@ describe CurationConcerns::ScannedResourcesController do
       expect(assigns(:members).map(&:id)).to eq ["2"]
     end
   end
+
+  describe "#structure" do
+    before do
+      sign_in user
+    end
+    let(:solr) { ActiveFedora.solr.conn }
+    let(:resource) do
+      r = FactoryGirl.build(:scanned_resource)
+      allow(r).to receive(:id).and_return("1")
+      allow(r.list_source).to receive(:id).and_return("3")
+      r
+    end
+    let(:file_set) do
+      f = FactoryGirl.build(:file_set)
+      allow(f).to receive(:id).and_return("2")
+      f
+    end
+    before do
+      resource.ordered_members << file_set
+      solr.add file_set.to_solr.merge(ordered_by_ssim: [resource.id])
+      solr.add resource.to_solr
+      solr.add resource.list_source.to_solr
+      solr.commit
+    end
+    it "sets @members" do
+      get :structure, id: "1"
+
+      expect(assigns(:members).map(&:id)).to eq ["2"]
+    end
+    it "sets @logical_order" do
+      obj = double("logical order object")
+      allow_any_instance_of(ScannedResourceShowPresenter).to receive(:logical_order_object).and_return(obj)
+      get :structure, id: "1"
+
+      expect(assigns(:logical_order)).to eq obj
+    end
+  end
+
+  describe "#save_structure" do
+    let(:resource) { FactoryGirl.create(:scanned_resource, user: user) }
+    let(:file_set) { FactoryGirl.create(:file_set, user: user) }
+    let(:user) { FactoryGirl.create(:admin) }
+    before do
+      sign_in user
+      resource.ordered_members << file_set
+      resource.save
+    end
+    let(:nodes) do
+      [
+        {
+          "label": "Chapter 1",
+          "nodes": [
+            {
+              "proxy": file_set.id
+            }
+          ]
+        }
+      ]
+    end
+    it "persists order" do
+      post :save_structure, nodes: nodes, id: resource.id
+
+      expect(response.status).to eq 200
+      expect(resource.reload.logical_order.order).to eq({ "nodes": nodes }.with_indifferent_access)
+    end
+  end
 end

--- a/spec/decorators/with_proxy_for_object/factory_spec.rb
+++ b/spec/decorators/with_proxy_for_object/factory_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe WithProxyForObject::Factory do
+  subject { described_class.new(members) }
+  let(:members) do
+    [
+      instance_double(ScannedResource, id: "test", to_s: "Banana")
+    ]
+  end
+
+  it "can be used to build nodes for a logical order recursively" do
+    obj = subject.new({ "nodes": [{ label: "Chapter 1" }] }, nil)
+    expect(obj).to respond_to :proxy_for_object
+    expect(obj.nodes.first).to respond_to :proxy_for_object
+  end
+end

--- a/spec/decorators/with_proxy_for_object_spec.rb
+++ b/spec/decorators/with_proxy_for_object_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe WithProxyForObject do
+  subject { described_class.new(logical_order, members) }
+  let(:logical_order) do
+    instance_double(LogicalOrder, proxy_for_id: "test", label: label)
+  end
+  let(:label) {}
+  let(:members) do
+    [
+      instance_double(ScannedResource, id: "test", to_s: "Banana")
+    ]
+  end
+
+  describe "#proxy_for_object" do
+    it "returns the matching object" do
+      expect(subject.proxy_for_object).to eq members.first
+    end
+  end
+
+  describe "#label" do
+    context "when there's a node label" do
+      let(:label) { "plum" }
+      it "returns it" do
+        expect(subject.label).to eq "plum"
+      end
+    end
+    context "when there is only a label on the resource" do
+      it "returns it" do
+        expect(subject.label).to eq "Banana"
+      end
+    end
+  end
+
+  describe "#unstructured_objects" do
+    let(:logical_order) do
+      WithProxyForObject::Factory.new(members).new("nodes": [
+        {
+          "proxy": "test"
+        }
+      ])
+    end
+    let(:members) do
+      [
+        instance_double(ScannedResource, id: "test", to_s: "Banana"),
+        member_2
+      ]
+    end
+    let(:member_2) { instance_double(ScannedResource, id: "t", to_s: "Alfafa") }
+    it "returns nodes in members but not in structure" do
+      expect(subject.unstructured_objects.nodes.length).to eq 1
+      expect(subject.unstructured_objects.nodes.first.proxy_for_object).to eq member_2
+    end
+  end
+end

--- a/spec/javascripts/fixtures/structure_1.html
+++ b/spec/javascripts/fixtures/structure_1.html
@@ -1,0 +1,110 @@
+<ul class="sortable ui-sortable">
+  <li data-id="#g70151760461700">
+    <div class="ui-sortable-handle">
+      <div class="panel panel-default ui-sortable-handle">
+        <div class="panel-heading ui-sortable-handle">
+          <div class="title ui-sortable-handle">
+            <input id="label" name="label" type="text" value="Chapter 1">
+          </div>
+          <div class="toolbar ui-sortable-handle">
+            <a data-action="remove-list" href="" title="Remove"><span class="glyphicon glyphicon-remove"></span></a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <ul>
+      <li data-id="#g70151760644600" data-proxy="a">
+        <div class="ui-sortable-handle">
+          <div class="panel panel-default ui-sortable-handle">
+            <div class="panel-heading ui-sortable-handle">
+              <div class="title ui-sortable-handle">
+                Page 1
+              </div>
+              <div class="toolbar ui-sortable-handle"></div>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li data-id="#g70151760569220" data-proxy="b">
+        <div class="ui-sortable-handle">
+          <div class="panel panel-default ui-sortable-handle">
+            <div class="panel-heading ui-sortable-handle">
+              <div class="title ui-sortable-handle">
+                Page 2
+              </div>
+              <div class="toolbar ui-sortable-handle"></div>
+            </div>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </li>
+  <li data-id="#g70151687137400">
+    <div class="ui-sortable-handle">
+      <div class="panel panel-default ui-sortable-handle">
+        <div class="panel-heading ui-sortable-handle">
+          <div class="title ui-sortable-handle">
+            <input id="label" name="label" type="text" value="Chapter 2">
+          </div>
+          <div class="toolbar ui-sortable-handle">
+            <a data-action="remove-list" href="" title="Remove"><span class="glyphicon glyphicon-remove"></span></a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <ul>
+      <li data-id="#g70151687084480" data-proxy="c">
+        <div class="ui-sortable-handle">
+          <div class="panel panel-default ui-sortable-handle">
+            <div class="panel-heading ui-sortable-handle">
+              <div class="title ui-sortable-handle">
+                Page 3
+              </div>
+              <div class="toolbar ui-sortable-handle"></div>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li data-id="#g70151687384900" data-proxy="d">
+        <div class="ui-sortable-handle">
+          <div class="panel panel-default ui-sortable-handle">
+            <div class="panel-heading ui-sortable-handle">
+              <div class="title ui-sortable-handle">
+                color.tif
+              </div>
+              <div class="toolbar ui-sortable-handle"></div>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li class="">
+        <div>
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <div class="title">
+                <input id="label" name="label" type="text" value="Chapter 2a">
+              </div>
+              <div class="toolbar">
+                <a data-action="remove-list" href="" title="Remove "><span class="glyphicon glyphicon-remove"></span></a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <ul>
+          <li class="" data-id="#g70151760341720" data-proxy="e">
+            <div class="ui-sortable-handle">
+              <div class="panel panel-default ui-sortable-handle">
+                <div class="panel-heading ui-sortable-handle">
+                  <div class="title ui-sortable-handle">
+                    gray.tif
+                  </div>
+                  <div class="toolbar ui-sortable-handle"></div>
+                </div>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+</ul>

--- a/spec/javascripts/fixtures/structure_basic.html
+++ b/spec/javascripts/fixtures/structure_basic.html
@@ -1,0 +1,16 @@
+<ul class="sortable ui-sortable">
+  <li id="node" data-id="#g70151760461700">
+    <div class="ui-sortable-handle">
+      <div class="panel panel-default ui-sortable-handle">
+        <div class="panel-heading ui-sortable-handle">
+          <div class="title ui-sortable-handle">
+            <input type="text" name="label" id="label" value="Chapter 1">
+          </div>
+          <div class="toolbar ui-sortable-handle">
+            <a href="" title="Remove" data-action="remove-list"><span class="glyphicon glyphicon-remove"></span></a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </li>
+</ul>

--- a/spec/javascripts/fixtures/structure_double_nested.html
+++ b/spec/javascripts/fixtures/structure_double_nested.html
@@ -1,0 +1,47 @@
+<ul class="sortable ui-sortable">
+  <li data-id="#g70151760461700">
+    <div class="ui-sortable-handle">
+      <div class="panel panel-default ui-sortable-handle">
+        <div class="panel-heading ui-sortable-handle">
+          <div class="title ui-sortable-handle">
+            <input type="text" name="label" id="label" value="Chapter 1">
+          </div>
+          <div class="toolbar ui-sortable-handle">
+            <a href="" title="Remove" data-action="remove-list"><span class="glyphicon glyphicon-remove"></span></a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <ul>
+      <li data-id="#g70151760461700">
+        <div class="ui-sortable-handle">
+          <div class="panel panel-default ui-sortable-handle">
+            <div class="panel-heading ui-sortable-handle">
+              <div class="title ui-sortable-handle">
+                <input type="text" name="label" id="label" value="Chapter 2">
+              </div>
+              <div class="toolbar ui-sortable-handle">
+                <a href="" title="Remove" data-action="remove-list"><span class="glyphicon glyphicon-remove"></span></a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <ul>
+          <li data-id="#g70151760644600" data-proxy="a">
+            <div class="ui-sortable-handle">
+              <div class="panel panel-default ui-sortable-handle">
+                <div class="panel-heading ui-sortable-handle">
+                  <div class="title ui-sortable-handle">
+                    Page 1
+                  </div>
+                  <div class="toolbar ui-sortable-handle">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+</ul>

--- a/spec/javascripts/fixtures/structure_nested.html
+++ b/spec/javascripts/fixtures/structure_nested.html
@@ -1,0 +1,31 @@
+<ul class="sortable ui-sortable">
+  <li data-id="#g70151760461700">
+    <div class="ui-sortable-handle">
+      <div class="panel panel-default ui-sortable-handle">
+        <div class="panel-heading ui-sortable-handle">
+          <div class="title ui-sortable-handle">
+            <input type="text" name="label" id="label" value="Chapter 1">
+          </div>
+          <div class="toolbar ui-sortable-handle">
+            <a href="" title="Remove" data-action="remove-list"><span class="glyphicon glyphicon-remove"></span></a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <ul>
+      <li data-id="#g70151760644600" data-proxy="a">
+        <div class="ui-sortable-handle">
+          <div class="panel panel-default ui-sortable-handle">
+            <div class="panel-heading ui-sortable-handle">
+              <div class="title ui-sortable-handle">
+                Page 1
+              </div>
+              <div class="toolbar ui-sortable-handle">
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </li>
+</ul>

--- a/spec/javascripts/fixtures/structure_siblings.html
+++ b/spec/javascripts/fixtures/structure_siblings.html
@@ -1,0 +1,30 @@
+<ul class="sortable ui-sortable">
+  <li id="node" data-id="#g70151760461700">
+    <div class="ui-sortable-handle">
+      <div class="panel panel-default ui-sortable-handle">
+        <div class="panel-heading ui-sortable-handle">
+          <div class="title ui-sortable-handle">
+            <input type="text" name="label" id="label" value="Chapter 1">
+          </div>
+          <div class="toolbar ui-sortable-handle">
+            <a href="" title="Remove" data-action="remove-list"><span class="glyphicon glyphicon-remove"></span></a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </li>
+  <li id="node2" data-id="#g70151760461704">
+    <div class="ui-sortable-handle">
+      <div class="panel panel-default ui-sortable-handle">
+        <div class="panel-heading ui-sortable-handle">
+          <div class="title ui-sortable-handle">
+            <input type="text" name="label" id="label" value="Chapter 2">
+          </div>
+          <div class="toolbar ui-sortable-handle">
+            <a href="" title="Remove" data-action="remove-list"><span class="glyphicon glyphicon-remove"></span></a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </li>
+</ul>

--- a/spec/javascripts/helpers/spec_helper.js
+++ b/spec/javascripts/helpers/spec_helper.js
@@ -1,0 +1,4 @@
+//= require jasmine-jquery
+// rake spec:javascript loads specs relative to the tmp/jasmine/runner.html, need
+// to override:
+jasmine.getFixtures().fixturesPath="../../spec/javascripts/fixtures"

--- a/spec/javascripts/label_generator_spec.js
+++ b/spec/javascripts/label_generator_spec.js
@@ -1,4 +1,3 @@
-//= require label_generator
 describe("frontBackLabeler", function() {
 
   it("just counts up from 1 by default", function() {

--- a/spec/javascripts/structure_parser_spec.coffee
+++ b/spec/javascripts/structure_parser_spec.coffee
@@ -1,0 +1,125 @@
+describe "StructureParser", () ->
+  structure = null
+  describe "serialize", () ->
+    describe "a single node", () ->
+      beforeEach () ->
+        loadFixtures('structure_basic.html')
+        structure = new StructureParser($(".sortable"))
+      it "returns a serialized form of the structure", ->
+        expected_result = {
+          'nodes': [
+            {
+              'label': 'Chapter 1'
+            }
+          ]
+        }
+        expect(structure.serialize).toEqual(expected_result)
+    describe "two sibling nodes", () ->
+      beforeEach () ->
+        loadFixtures('structure_siblings.html')
+        structure = new StructureParser($(".sortable"))
+      it "returns a serialized form", ->
+        expected_result = {
+          "nodes": [
+            {
+              'label': 'Chapter 1'
+            },
+            {
+              'label': 'Chapter 2'
+            }
+          ]
+        }
+        expect(structure.serialize).toEqual(expected_result)
+    describe "nested nodes", () ->
+      beforeEach () ->
+        loadFixtures('structure_nested.html')
+        structure = new StructureParser($(".sortable"))
+      it "returns a serialized form", ->
+        expected_result = {
+          "nodes": [
+            {
+              'label': 'Chapter 1',
+              'nodes': [
+                {
+                  'proxy': 'a'
+                }
+              ]
+            }
+          ]
+        }
+        expect(structure.serialize).toEqual(expected_result)
+    describe "doubly-nested nodes", () ->
+      beforeEach () ->
+        loadFixtures('structure_double_nested.html')
+        structure = new StructureParser($(".sortable"))
+      it "returns a serialized form", ->
+        expected_result = {
+          "nodes": [
+            {
+              "label": "Chapter 1",
+              "nodes": [
+                {
+                  "label": "Chapter 2",
+                  "nodes": [
+                    {
+                      "proxy": "a"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        expect(structure.serialize).toEqual(expected_result)
+    describe "complicated example", () ->
+      beforeEach () ->
+        loadFixtures('structure_1.html')
+        structure = new StructureParser($(".sortable"))
+      it "returns a serialized form", ->
+        expected_result = {
+          "nodes": [
+            {
+              "label": "Chapter 1",
+              "nodes": [
+                {
+                  "proxy": "a"
+                },
+                {
+                  "proxy": "b"
+                }
+              ]
+            },
+            {
+              "label": "Chapter 2",
+              "nodes": [
+                {
+                  "proxy": "c"
+                },
+                {
+                  "proxy": "d"
+                },
+                {
+                  "label": "Chapter 2a",
+                  "nodes": [
+                    {
+                      "proxy": "e"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        expect(structure.serialize).toEqual(expected_result)
+
+describe "StructureNode", () ->
+  node = null
+  beforeEach () ->
+    loadFixtures('structure_basic.html')
+    node = new StructureNode($('#node'))
+  describe "label", () ->
+    it "returns the value of the input", ->
+      expect(node.label).toEqual("Chapter 1")
+  describe "serialize", () ->
+    it "returns a serialized object", ->
+      expect(node.serialize).toEqual({"label": "Chapter 1"})

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -17,6 +17,7 @@ css_dir: "app/assets/stylesheets"
 # list of file expressions to include as source files
 # relative path from src_dir
 src_files:
+  - "assets/jasmine-jquery.js"
   - "application.{js.coffee,js,coffee}"
 
 # list of file expressions to include as css files
@@ -42,7 +43,7 @@ helpers:
 # list of file expressions to include as specs into spec runner
 # relative path from spec_dir
 spec_files:
-  - "**/*[Ss]pec.{js.coffee,js,coffee}"
+  - "**/*[Ss]pec.{js.coffee,js,coffee,es6}"
 
 # path to directory of temporary files
 # (spec runner and asset cache)

--- a/spec/presenters/scanned_resource_show_presenter_spec.rb
+++ b/spec/presenters/scanned_resource_show_presenter_spec.rb
@@ -27,4 +27,16 @@ RSpec.describe ScannedResourceShowPresenter do
       expect(subject.pending_uploads).to eq [pending_upload]
     end
   end
+
+  describe "#logical_order_object" do
+    before do
+      allow(solr_document).to receive(:logical_order).and_return("nodes": [{ label: "Chapter 1", proxy: "test" }])
+    end
+    it "returns a logical order object" do
+      expect(subject.logical_order_object.nodes.length).to eq 1
+    end
+    it "returns decorated nodes" do
+      expect(subject.logical_order_object.nodes.first).to respond_to :proxy_for_object
+    end
+  end
 end

--- a/spec/values/canvas_id_spec.rb
+++ b/spec/values/canvas_id_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe CanvasID do
+  subject { described_class.new(id, parent_path) }
+  let(:parent_path) { "http://test.com/manifest" }
+  let(:id) { "1" }
+
+  describe "#to_s" do
+    it "returns a good path" do
+      expect(subject.to_s).to eq "http://test.com/manifest/canvas/1"
+    end
+  end
+end

--- a/spec/values/logical_order_graph_spec.rb
+++ b/spec/values/logical_order_graph_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe LogicalOrderGraph do
+  subject { described_class.new(graph, head_subject) }
+
+  let(:graph) { order.to_graph }
+  let(:order) { LogicalOrder.new(params) }
+  let(:head_subject) { order.rdf_subject }
+  let(:params) do
+    {
+      "nodes" => [
+        {
+          "label": "Chapter 1",
+          "nodes": [
+            {
+              "label": "Page 1",
+              "proxy": "a"
+            },
+            {
+              "label": "Page 1",
+              "proxy": "b"
+            },
+            {
+              "label": "Chapter 1b",
+              "nodes": [
+                {
+                  "label": "Page 2",
+                  "proxy": "c"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Chapter 2",
+          "nodes": [
+            {
+              "label": "Page 3",
+              "proxy": "d"
+            }
+          ]
+        }
+      ]
+    }.with_indifferent_access
+  end
+
+  describe "#to_h" do
+    it "returns a good hash" do
+      expect(subject.to_h).to eq params
+    end
+  end
+
+  describe "#nodes" do
+    it "returns an array of nodes" do
+      expect(subject.nodes.length).to eq 2
+    end
+    it "returns labels" do
+      expect(subject.nodes.first.label).to eq "Chapter 1"
+    end
+  end
+
+  describe "#proxy_for_id" do
+    let(:params) do
+      {
+        "nodes": [
+          {
+            "label": "Page 1",
+            "proxy": "a"
+          }
+        ]
+      }
+    end
+    it "returns it" do
+      expect(subject.nodes.first.proxy_for_id).to eq "a"
+    end
+  end
+end

--- a/spec/values/logical_order_spec.rb
+++ b/spec/values/logical_order_spec.rb
@@ -1,0 +1,177 @@
+require 'rails_helper'
+
+RSpec.describe LogicalOrder do
+  subject { described_class.new(params, label) }
+  let(:label) {}
+  let(:params) do
+    {
+      "nodes" => [
+        {
+          "label": "Chapter 1",
+          "nodes": [
+            {
+              "label": "Page 1",
+              "proxy": "a"
+            },
+            {
+              "label": "Page 1",
+              "proxy": "b"
+            },
+            {
+              "label": "Chapter 1b",
+              "nodes": [
+                {
+                  "label": "Page 2",
+                  "proxy": "c"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Chapter 2",
+          "nodes": [
+            {
+              "label": "Page 3",
+              "proxy": "d"
+            }
+          ]
+        }
+      ]
+    }
+  end
+
+  it "can accept a URI" do
+    expect { described_class.new(params, RDF::URI("http://test.com/bla")) }.not_to raise_error
+  end
+
+  describe "#nodes" do
+    it "returns the two nodes" do
+      expect(subject.nodes.length).to eq 2
+    end
+    it "returns orders with labels" do
+      expect(subject.nodes.map(&:label)).to eq ["Chapter 1", "Chapter 2"]
+    end
+    it "has sub-nodes with titles" do
+      expect(subject.nodes.first.nodes.map(&:label)).to eq ["Page 1", "Page 1", "Chapter 1b"]
+    end
+    it "goes N levels deep" do
+      deep_node = subject.nodes.first.nodes.first
+      expect(deep_node.label).to eq "Page 1"
+      expect(deep_node.nodes).to eq []
+      expect(deep_node.proxy_for_id).to eq "a"
+    end
+  end
+
+  describe "a flat thing with two pages" do
+    let(:params) do
+      {
+        "nodes": [
+          {
+            "label": "Page 1",
+            "proxy": "a"
+          },
+          {
+            "label": "Page 2",
+            "proxy": "b"
+          }
+        ]
+      }
+    end
+    it "has two nodes" do
+      expect(subject.nodes.length).to eq 2
+    end
+  end
+
+  describe "#to_graph" do
+    let(:result) { subject.to_graph }
+    context "for a single level node" do
+      let(:params) do
+        {
+          "nodes": [
+            {
+              "proxy": "a"
+            }
+          ]
+        }
+      end
+      let(:label) { "Test Label" }
+      it "returns a tiny ordered graph"do
+        expect(result.statements.to_a.length).to eq 3
+      end
+    end
+    context "for sibling nodes" do
+      let(:params) do
+        {
+          "nodes": [
+            {
+              "label": "Chapter 1",
+              "proxy": "a"
+            },
+            {
+              "label": "Chapter 1",
+              "proxy": "a"
+            }
+          ]
+        }
+      end
+      it "builds the right number of statements" do
+        expect(result.statements.to_a.length).to eq 8
+      end
+    end
+    context "for two deep nodes" do
+      let(:params) do
+        {
+          "nodes": [
+            {
+              "label": "Chapter 1",
+              "proxy": "a"
+            }
+          ]
+        }
+      end
+      it "doesn't have two-level deep nodes" do
+        expect(subject.nodes.first.nodes).to eq []
+      end
+      it "returns a connected graph" do
+        expect(result.statements.to_a.length).to eq 4
+        expect(result.subjects.to_a.length).to eq 2
+        expect(result.predicates.to_a).to contain_exactly(
+          RDF::Vocab::IANA.first,
+          RDF::Vocab::IANA.last,
+          RDF::Vocab::RDFS.label,
+          RDF::Vocab::ORE.proxyFor
+        )
+      end
+    end
+    context "for two siblings, one with deep" do
+      let(:params) do
+        {
+          "nodes": [
+            {
+              "label": "Chapter 1",
+              "nodes": [
+                {
+                  "label": "Chapter 1a",
+                  "proxy": "a"
+                }
+              ]
+            },
+            {
+              "label": "Chapter 1",
+              "proxy": "b"
+            }
+          ]
+        }
+      end
+      it "returns a correct graph" do
+        expect(result.statements.to_a.length).to eq 11
+      end
+    end
+    context "for a big graph" do
+      it "builds it" do
+        expect(result.statements.to_a.length).to eq 25
+      end
+    end
+  end
+end

--- a/spec/views/curation_concerns/scanned_resources/_show_actions.html.erb_spec.rb
+++ b/spec/views/curation_concerns/scanned_resources/_show_actions.html.erb_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe "curation_concerns/scanned_resources/_show_actions.html.erb" do
   it "renders a reorder link" do
     expect(rendered).to have_link "Bulk Edit", bulk_edit_curation_concerns_scanned_resource_path(id: resource.id)
   end
+  it "renders an Edit Structure link" do
+    expect(rendered).to have_link "Edit Structure", structure_curation_concerns_scanned_resource_path(id: resource.id)
+  end
   it "renders a server upload form" do
     expect(rendered).to have_selector "form#browse-everything-form"
     expect(rendered).to have_selector "button.browse-everything"

--- a/spec/views/curation_concerns/scanned_resources/structure.html.erb_spec.rb
+++ b/spec/views/curation_concerns/scanned_resources/structure.html.erb_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe "curation_concerns/scanned_resources/structure" do
+  let(:logical_order) do
+    WithProxyForObject::Factory.new(members).new(params)
+  end
+  let(:params) do
+    {
+      nodes: [
+        {
+          label: "Chapter 1",
+          nodes: [
+            {
+              proxy: "a"
+            }
+          ]
+        }
+      ]
+    }
+  end
+  let(:members) do
+    [
+      instance_double(FileSet, id: "a", to_s: "Banana"),
+      instance_double(FileSet, id: "b", to_s: "Banana")
+    ]
+  end
+  let(:scanned_resource) { ScannedResource.new("test") }
+  before do
+    assign(:logical_order, logical_order)
+    assign(:presenter, scanned_resource)
+    render
+  end
+  it "renders a li per node" do
+    expect(rendered).to have_selector("li", count: 3)
+  end
+  it "renders a ul per order" do
+    expect(rendered).to have_selector("ul", count: 2)
+  end
+  it "renders labels of chapters" do
+    expect(rendered).to have_selector("input[value='Chapter 1']")
+  end
+  it "renders proxy nodes" do
+    expect(rendered).to have_selector("li[data-proxy='a']")
+  end
+  it "renders unstructured nodes" do
+    expect(rendered).to have_selector("li[data-proxy='b']")
+  end
+end

--- a/vendor/assets/javascripts/nestedSortable/jquery.mjs.nestedSortable.js
+++ b/vendor/assets/javascripts/nestedSortable/jquery.mjs.nestedSortable.js
@@ -1,0 +1,902 @@
+/*
+ * jQuery UI Nested Sortable
+ * v 2.0 / 29 oct 2012
+ * http://mjsarfatti.com/sandbox/nestedSortable
+ *
+ * Depends on:
+ *	 jquery.ui.sortable.js 1.10+
+ *
+ * Copyright (c) 2010-2013 Manuele J Sarfatti
+ * Licensed under the MIT License
+ * http://www.opensource.org/licenses/mit-license.php
+ */
+(function( factory ) {
+  "use strict";
+
+  var define = window.define;
+
+  if ( typeof define === "function" && define.amd ) {
+
+    // AMD. Register as an anonymous module.
+    define([
+      "jquery",
+      "jquery-ui/sortable"
+    ], factory );
+  } else {
+
+    // Browser globals
+    factory( window.jQuery );
+  }
+}(function($) {
+  "use strict";
+
+  function isOverAxis( x, reference, size ) {
+    return ( x > reference ) && ( x < ( reference + size ) );
+  }
+
+  $.widget("mjs.nestedSortable", $.extend({}, $.ui.sortable.prototype, {
+
+    options: {
+      disableParentChange: false,
+      doNotClear: false,
+      expandOnHover: 700,
+      isAllowed: function() { return true; },
+      isTree: false,
+      listType: "ol",
+      maxLevels: 0,
+      protectRoot: false,
+      rootID: null,
+      rtl: false,
+      startCollapsed: false,
+      tabSize: 20,
+
+      branchClass: "mjs-nestedSortable-branch",
+      collapsedClass: "mjs-nestedSortable-collapsed",
+      disableNestingClass: "mjs-nestedSortable-no-nesting",
+      errorClass: "mjs-nestedSortable-error",
+      expandedClass: "mjs-nestedSortable-expanded",
+      hoveringClass: "mjs-nestedSortable-hovering",
+      leafClass: "mjs-nestedSortable-leaf",
+      disabledClass: "mjs-nestedSortable-disabled"
+    },
+
+    _create: function() {
+      var self = this,
+        err;
+
+      this.element.data("ui-sortable", this.element.data("mjs-nestedSortable"));
+
+      // mjs - prevent browser from freezing if the HTML is not correct
+      if (!this.element.is(this.options.listType)) {
+        err = "nestedSortable: " +
+          "Please check that the listType option is set to your actual list type";
+
+        throw new Error(err);
+      }
+
+      // if we have a tree with expanding/collapsing functionality,
+      // force 'intersect' tolerance method
+      if (this.options.isTree && this.options.expandOnHover) {
+        this.options.tolerance = "intersect";
+      }
+
+      $.ui.sortable.prototype._create.apply(this, arguments);
+
+      // prepare the tree by applying the right classes
+      // (the CSS is responsible for actual hide/show functionality)
+      if (this.options.isTree) {
+        $(this.items).each(function() {
+          var $li = this.item,
+            hasCollapsedClass = $li.hasClass(self.options.collapsedClass),
+            hasExpandedClass = $li.hasClass(self.options.expandedClass);
+
+          if ($li.children(self.options.listType).length) {
+            $li.addClass(self.options.branchClass);
+            // expand/collapse class only if they have children
+
+            if ( !hasCollapsedClass && !hasExpandedClass ) {
+              if (self.options.startCollapsed) {
+                $li.addClass(self.options.collapsedClass);
+              } else {
+                $li.addClass(self.options.expandedClass);
+              }
+            }
+          } else {
+            $li.addClass(self.options.leafClass);
+          }
+        });
+      }
+    },
+
+    _destroy: function() {
+      this.element
+      .removeData("mjs-nestedSortable")
+      .removeData("ui-sortable");
+      return $.ui.sortable.prototype._destroy.apply(this, arguments);
+    },
+
+    _mouseDrag: function(event) {
+      var i,
+      item,
+      itemElement,
+      intersection,
+      self = this,
+        o = this.options,
+        scrolled = false,
+        $document = $(document),
+        previousTopOffset,
+      parentItem,
+      level,
+      childLevels,
+      itemAfter,
+      itemBefore,
+      newList,
+      method,
+      a,
+      previousItem,
+      nextItem,
+      helperIsNotSibling;
+
+      //Compute the helpers position
+      this.position = this._generatePosition(event);
+      this.positionAbs = this._convertPositionTo("absolute");
+
+      if (!this.lastPositionAbs) {
+        this.lastPositionAbs = this.positionAbs;
+      }
+
+      //Do scrolling
+      if (this.options.scroll) {
+        if (this.scrollParent[0] !== document && this.scrollParent[0].tagName !== "HTML") {
+
+          if (
+            (
+              this.overflowOffset.top +
+                this.scrollParent[0].offsetHeight
+            ) -
+              event.pageY <
+            o.scrollSensitivity
+          ) {
+            scrolled = this.scrollParent.scrollTop() + o.scrollSpeed;
+            this.scrollParent.scrollTop(scrolled);
+          } else if (
+            event.pageY -
+            this.overflowOffset.top <
+          o.scrollSensitivity
+          ) {
+            scrolled = this.scrollParent.scrollTop() - o.scrollSpeed;
+            this.scrollParent.scrollTop(scrolled);
+          }
+
+          if (
+            (
+              this.overflowOffset.left +
+                this.scrollParent[0].offsetWidth
+            ) -
+              event.pageX <
+            o.scrollSensitivity
+          ) {
+            scrolled = this.scrollParent.scrollLeft() + o.scrollSpeed;
+            this.scrollParent.scrollLeft(scrolled);
+          } else if (
+            event.pageX -
+            this.overflowOffset.left <
+          o.scrollSensitivity
+          ) {
+            scrolled = this.scrollParent.scrollLeft() - o.scrollSpeed;
+            this.scrollParent.scrollLeft(scrolled);
+          }
+
+        } else {
+
+          if (
+            event.pageY -
+            $document.scrollTop() <
+          o.scrollSensitivity
+          ) {
+            scrolled = $document.scrollTop() - o.scrollSpeed;
+            $document.scrollTop(scrolled);
+          } else if (
+            $(window).height() -
+            (
+              event.pageY -
+                $document.scrollTop()
+            ) <
+            o.scrollSensitivity
+          ) {
+            scrolled = $document.scrollTop() + o.scrollSpeed;
+            $document.scrollTop(scrolled);
+          }
+
+          if (
+            event.pageX -
+            $document.scrollLeft() <
+          o.scrollSensitivity
+          ) {
+            scrolled = $document.scrollLeft() - o.scrollSpeed;
+            $document.scrollLeft(scrolled);
+          } else if (
+            $(window).width() -
+            (
+              event.pageX -
+                $document.scrollLeft()
+            ) <
+            o.scrollSensitivity
+          ) {
+            scrolled = $document.scrollLeft() + o.scrollSpeed;
+            $document.scrollLeft(scrolled);
+          }
+
+        }
+
+        if (scrolled !== false && $.ui.ddmanager && !o.dropBehaviour) {
+          $.ui.ddmanager.prepareOffsets(this, event);
+        }
+      }
+
+      //Regenerate the absolute position used for position checks
+      this.positionAbs = this._convertPositionTo("absolute");
+
+      // mjs - find the top offset before rearrangement,
+      previousTopOffset = this.placeholder.offset().top;
+
+      //Set the helper position
+      if (!this.options.axis || this.options.axis !== "y") {
+        this.helper[0].style.left = this.position.left + "px";
+      }
+      if (!this.options.axis || this.options.axis !== "x") {
+        this.helper[0].style.top = (this.position.top) + "px";
+      }
+
+      // mjs - check and reset hovering state at each cycle
+      this.hovering = this.hovering ? this.hovering : null;
+      this.mouseentered = this.mouseentered ? this.mouseentered : false;
+
+      // mjs - let's start caching some variables
+      (function() {
+        var _parentItem = this.placeholder.parent().parent();
+        if (_parentItem && _parentItem.closest(".ui-sortable").length) {
+          parentItem = _parentItem;
+        }
+      }.call(this));
+
+      level = this._getLevel(this.placeholder);
+      childLevels = this._getChildLevels(this.helper);
+      newList = document.createElement(o.listType);
+
+      //Rearrange
+      for (i = this.items.length - 1; i >= 0; i--) {
+
+        //Cache variables and intersection, continue if no intersection
+        item = this.items[i];
+        itemElement = item.item[0];
+        intersection = this._intersectsWithPointer(item);
+        if (!intersection) {
+          continue;
+        }
+
+        // Only put the placeholder inside the current Container, skip all
+        // items form other containers. This works because when moving
+        // an item from one container to another the
+        // currentContainer is switched before the placeholder is moved.
+        //
+        // Without this moving items in "sub-sortables" can cause the placeholder to jitter
+        // beetween the outer and inner container.
+        if (item.instance !== this.currentContainer) {
+          continue;
+        }
+
+        // No action if intersected item is disabled
+        // and the element above or below in the direction we're going is also disabled
+        if (itemElement.className.indexOf(o.disabledClass) !== -1) {
+          // Note: intersection hardcoded direction values from
+          // jquery.ui.sortable.js:_intersectsWithPointer
+          if (intersection === 2) {
+            // Going down
+            itemAfter = this.items[i + 1];
+            if (itemAfter && itemAfter.item.hasClass(o.disabledClass)) {
+              continue;
+            }
+
+          } else if (intersection === 1) {
+            // Going up
+            itemBefore = this.items[i - 1];
+            if (itemBefore && itemBefore.item.hasClass(o.disabledClass)) {
+              continue;
+            }
+          }
+        }
+
+        method = intersection === 1 ? "next" : "prev";
+
+        // cannot intersect with itself
+        // no useless actions that have been done before
+        // no action if the item moved is the parent of the item checked
+        if (itemElement !== this.currentItem[0] &&
+            this.placeholder[method]()[0] !== itemElement &&
+              !$.contains(this.placeholder[0], itemElement) &&
+                (
+                  this.options.type === "semi-dynamic" ?
+                  !$.contains(this.element[0], itemElement) :
+                true
+        )
+           ) {
+
+             // mjs - we are intersecting an element:
+             // trigger the mouseenter event and store this state
+             if (!this.mouseentered) {
+               $(itemElement).mouseenter();
+               this.mouseentered = true;
+             }
+
+             // mjs - if the element has children and they are hidden,
+             // show them after a delay (CSS responsible)
+             if (o.isTree && $(itemElement).hasClass(o.collapsedClass) && o.expandOnHover) {
+               if (!this.hovering) {
+                 $(itemElement).addClass(o.hoveringClass);
+                 this.hovering = window.setTimeout(function() {
+                   $(itemElement)
+                   .removeClass(o.collapsedClass)
+                   .addClass(o.expandedClass);
+
+                   self.refreshPositions();
+                   self._trigger("expand", event, self._uiHash());
+                 }, o.expandOnHover);
+               }
+             }
+
+             this.direction = intersection === 1 ? "down" : "up";
+
+             // mjs - rearrange the elements and reset timeouts and hovering state
+             if (this.options.tolerance === "pointer" || this._intersectsWithSides(item)) {
+               $(itemElement).mouseleave();
+               this.mouseentered = false;
+               $(itemElement).removeClass(o.hoveringClass);
+               if (this.hovering) {
+                 window.clearTimeout(this.hovering);
+               }
+               this.hovering = null;
+
+               // mjs - do not switch container if
+               // it's a root item and 'protectRoot' is true
+               // or if it's not a root item but we are trying to make it root
+               if (o.protectRoot &&
+                   !(
+                     this.currentItem[0].parentNode === this.element[0] &&
+                     // it's a root item
+                     itemElement.parentNode !== this.element[0]
+                   // it's intersecting a non-root item
+               )
+                  ) {
+                    if (this.currentItem[0].parentNode !== this.element[0] &&
+                        itemElement.parentNode === this.element[0]
+                       ) {
+
+                         if ( !$(itemElement).children(o.listType).length) {
+                           itemElement.appendChild(newList);
+                           if (o.isTree) {
+                             $(itemElement)
+                             .removeClass(o.leafClass)
+                             .addClass(o.branchClass + " " + o.expandedClass);
+                           }
+                         }
+
+                         if (this.direction === "down") {
+                           a = $(itemElement).prev().children(o.listType);
+                         } else {
+                           a = $(itemElement).children(o.listType);
+                         }
+
+                         if (a[0] !== undefined) {
+                           this._rearrange(event, null, a);
+                         }
+
+                       } else {
+                         this._rearrange(event, item);
+                       }
+                  } else if (!o.protectRoot) {
+                    this._rearrange(event, item);
+                  }
+             } else {
+               break;
+             }
+
+             // Clear emtpy ul's/ol's
+             this._clearEmpty(itemElement);
+
+             this._trigger("change", event, this._uiHash());
+             break;
+           }
+      }
+
+      // mjs - to find the previous sibling in the list,
+      // keep backtracking until we hit a valid list item.
+      (function() {
+        var _previousItem = this.placeholder.prev();
+        if (_previousItem.length) {
+          previousItem = _previousItem;
+        } else {
+          previousItem = null;
+        }
+      }.call(this));
+
+      if (previousItem != null) {
+        while (
+          previousItem[0].nodeName.toLowerCase() !== "li" ||
+          previousItem[0].className.indexOf(o.disabledClass) !== -1 ||
+        previousItem[0] === this.currentItem[0] ||
+      previousItem[0] === this.helper[0]
+        ) {
+          if (previousItem[0].previousSibling) {
+            previousItem = $(previousItem[0].previousSibling);
+          } else {
+            previousItem = null;
+            break;
+          }
+        }
+      }
+
+      // mjs - to find the next sibling in the list,
+      // keep stepping forward until we hit a valid list item.
+      (function() {
+        var _nextItem = this.placeholder.next();
+        if (_nextItem.length) {
+          nextItem = _nextItem;
+        } else {
+          nextItem = null;
+        }
+      }.call(this));
+
+      if (nextItem != null) {
+        while (
+          nextItem[0].nodeName.toLowerCase() !== "li" ||
+          nextItem[0].className.indexOf(o.disabledClass) !== -1 ||
+        nextItem[0] === this.currentItem[0] ||
+      nextItem[0] === this.helper[0]
+        ) {
+          if (nextItem[0].nextSibling) {
+            nextItem = $(nextItem[0].nextSibling);
+          } else {
+            nextItem = null;
+            break;
+          }
+        }
+      }
+
+      this.beyondMaxLevels = 0;
+
+      // mjs - if the item is moved to the left, send it one level up
+      // but only if it's at the bottom of the list
+      if (parentItem != null &&
+          nextItem == null &&
+            !(o.protectRoot && parentItem[0].parentNode == this.element[0]) &&
+              (
+                o.rtl &&
+                (
+                  this.positionAbs.left +
+                    this.helper.outerWidth() > parentItem.offset().left +
+                    parentItem.outerWidth()
+                ) ||
+                  !o.rtl && (this.positionAbs.left < parentItem.offset().left)
+      )
+         ) {
+
+           parentItem.after(this.placeholder[0]);
+           helperIsNotSibling = !parentItem
+           .children(o.listItem)
+           .children("li:visible:not(.ui-sortable-helper)")
+           .length;
+           if (o.isTree && helperIsNotSibling) {
+             parentItem
+             .removeClass(this.options.branchClass + " " + this.options.expandedClass)
+             .addClass(this.options.leafClass);
+           }
+           if(typeof parentItem !== 'undefined')
+             this._clearEmpty(parentItem[0]);
+           this._trigger("change", event, this._uiHash());
+           // mjs - if the item is below a sibling and is moved to the right,
+           // make it a child of that sibling
+         } else if (previousItem != null &&
+                    !previousItem.hasClass(o.disableNestingClass) &&
+                      (
+                        previousItem.children(o.listType).length &&
+                        previousItem.children(o.listType).is(":visible") ||
+                      !previousItem.children(o.listType).length
+         ) &&
+           !(o.protectRoot && this.currentItem[0].parentNode === this.element[0]) &&
+           (
+             o.rtl &&
+               (
+                 this.positionAbs.left +
+                   this.helper.outerWidth() <
+                 previousItem.offset().left +
+                   previousItem.outerWidth() -
+                   o.tabSize
+             ) ||
+               !o.rtl &&
+               (this.positionAbs.left > previousItem.offset().left + o.tabSize)
+         )
+                   ) {
+
+                     this._isAllowed(previousItem, level, level + childLevels + 1);
+
+                     if (!previousItem.children(o.listType).length) {
+                       previousItem[0].appendChild(newList);
+                       if (o.isTree) {
+                         previousItem
+                         .removeClass(o.leafClass)
+                         .addClass(o.branchClass + " " + o.expandedClass);
+                       }
+                     }
+
+                     // mjs - if this item is being moved from the top, add it to the top of the list.
+                     if (previousTopOffset && (previousTopOffset <= previousItem.offset().top)) {
+                       previousItem.children(o.listType).prepend(this.placeholder);
+                     } else {
+                       // mjs - otherwise, add it to the bottom of the list.
+                       previousItem.children(o.listType)[0].appendChild(this.placeholder[0]);
+                     }
+                     if(typeof parentItem !== 'undefined')
+                       this._clearEmpty(parentItem[0]);
+                     this._trigger("change", event, this._uiHash());
+                   } else {
+                     this._isAllowed(parentItem, level, level + childLevels);
+                   }
+
+                   //Post events to containers
+                   this._contactContainers(event);
+
+                   //Interconnect with droppables
+                   if ($.ui.ddmanager) {
+                     $.ui.ddmanager.drag(this, event);
+                   }
+
+                   //Call callbacks
+                   this._trigger("sort", event, this._uiHash());
+
+                   this.lastPositionAbs = this.positionAbs;
+                   return false;
+
+    },
+
+    _mouseStop: function(event) {
+      // mjs - if the item is in a position not allowed, send it back
+      if (this.beyondMaxLevels) {
+
+        this.placeholder.removeClass(this.options.errorClass);
+
+        if (this.domPosition.prev) {
+          $(this.domPosition.prev).after(this.placeholder);
+        } else {
+          $(this.domPosition.parent).prepend(this.placeholder);
+        }
+
+        this._trigger("revert", event, this._uiHash());
+
+      }
+
+      // mjs - clear the hovering timeout, just to be sure
+      $("." + this.options.hoveringClass)
+      .mouseleave()
+      .removeClass(this.options.hoveringClass);
+
+      this.mouseentered = false;
+      if (this.hovering) {
+        window.clearTimeout(this.hovering);
+      }
+      this.hovering = null;
+
+      this._relocate_event = event;
+      this._pid_current = $(this.domPosition.parent).parent().attr("id");
+      this._sort_current = this.domPosition.prev ? $(this.domPosition.prev).next().index() : 0;
+      $.ui.sortable.prototype._mouseStop.apply(this, arguments); //asybnchronous execution, @see _clear for the relocate event.
+    },
+
+    // mjs - this function is slightly modified
+    // to make it easier to hover over a collapsed element and have it expand
+    _intersectsWithSides: function(item) {
+
+      var half = this.options.isTree ? .8 : .5,
+        isOverBottomHalf = isOverAxis(
+          this.positionAbs.top + this.offset.click.top,
+          item.top + (item.height * half),
+          item.height
+      ),
+      isOverTopHalf = isOverAxis(
+        this.positionAbs.top + this.offset.click.top,
+        item.top - (item.height * half),
+        item.height
+      ),
+      isOverRightHalf = isOverAxis(
+        this.positionAbs.left + this.offset.click.left,
+        item.left + (item.width / 2),
+        item.width
+      ),
+      verticalDirection = this._getDragVerticalDirection(),
+        horizontalDirection = this._getDragHorizontalDirection();
+
+      if (this.floating && horizontalDirection) {
+        return (
+          (horizontalDirection === "right" && isOverRightHalf) ||
+            (horizontalDirection === "left" && !isOverRightHalf)
+        );
+      } else {
+        return verticalDirection && (
+          (verticalDirection === "down" && isOverBottomHalf) ||
+            (verticalDirection === "up" && isOverTopHalf)
+        );
+      }
+
+    },
+
+    _contactContainers: function() {
+
+      if (this.options.protectRoot && this.currentItem[0].parentNode === this.element[0] ) {
+        return;
+      }
+
+      $.ui.sortable.prototype._contactContainers.apply(this, arguments);
+
+    },
+
+    _clear: function() {
+      var i,
+      item;
+
+      $.ui.sortable.prototype._clear.apply(this, arguments);
+
+      //relocate event
+      if (!(this._pid_current === this._uiHash().item.parent().parent().attr("id") &&
+            this._sort_current === this._uiHash().item.index())) {
+        this._trigger("relocate", this._relocate_event, this._uiHash());
+      }
+
+      // mjs - clean last empty ul/ol
+      for (i = this.items.length - 1; i >= 0; i--) {
+        item = this.items[i].item[0];
+        this._clearEmpty(item);
+      }
+
+    },
+
+    serialize: function(options) {
+
+      var o = $.extend({}, this.options, options),
+        items = this._getItemsAsjQuery(o && o.connected),
+        str = [];
+
+      $(items).each(function() {
+        var res = ($(o.item || this).attr(o.attribute || "id") || "")
+        .match(o.expression || (/(.+)[-=_](.+)/)),
+        pid = ($(o.item || this).parent(o.listType)
+               .parent(o.items)
+               .attr(o.attribute || "id") || "")
+               .match(o.expression || (/(.+)[-=_](.+)/));
+
+               if (res) {
+                 str.push(
+                   (
+                     (o.key || res[1]) +
+                       "[" +
+                       (o.key && o.expression ? res[1] : res[2]) + "]"
+                   ) +
+                     "=" +
+                     (pid ? (o.key && o.expression ? pid[1] : pid[2]) : o.rootID));
+               }
+      });
+
+      if (!str.length && o.key) {
+        str.push(o.key + "=");
+      }
+
+      return str.join("&");
+
+    },
+
+    toHierarchy: function(options) {
+
+      var o = $.extend({}, this.options, options),
+        ret = [];
+
+      $(this.element).children(o.items).each(function() {
+        var level = _recursiveItems(this);
+        ret.push(level);
+      });
+
+      return ret;
+
+      function _recursiveItems(item) {
+        var id = ($(item).attr(o.attribute || "id") || "").match(o.expression || (/(.+)[-=_](.+)/)),
+          currentItem;
+        if (id) {
+          currentItem = {
+            "id": id[2]
+          };
+
+          if ($(item).children(o.listType).children(o.items).length > 0) {
+            currentItem.children = [];
+            $(item).children(o.listType).children(o.items).each(function() {
+              var level = _recursiveItems(this);
+              currentItem.children.push(level);
+            });
+          }
+          return currentItem;
+        }
+      }
+    },
+
+    toArray: function(options) {
+
+      var o = $.extend({}, this.options, options),
+        sDepth = o.startDepthCount || 0,
+        ret = [],
+        left = 1;
+
+      if (!o.excludeRoot) {
+        ret.push({
+          "item_id": o.rootID,
+          "parent_id": null,
+          "depth": sDepth,
+          "left": left,
+          "right": ($(o.items, this.element).length + 1) * 2
+        });
+        left++;
+      }
+
+      $(this.element).children(o.items).each(function() {
+        left = _recursiveArray(this, sDepth + 1, left);
+      });
+
+      ret = ret.sort(function(a, b) { return (a.left - b.left); });
+
+      return ret;
+
+      function _recursiveArray(item, depth, _left) {
+
+        var right = _left + 1,
+          id,
+        pid,
+        parentItem;
+
+        if ($(item).children(o.listType).children(o.items).length > 0) {
+          depth++;
+          $(item).children(o.listType).children(o.items).each(function() {
+            right = _recursiveArray($(this), depth, right);
+          });
+          depth--;
+        }
+
+        id = ($(item).attr(o.attribute || "id")).match(o.expression || (/(.+)[-=_](.+)/));
+
+        if (depth === sDepth + 1) {
+          pid = o.rootID;
+        } else {
+          parentItem = ($(item).parent(o.listType)
+                        .parent(o.items)
+                        .attr(o.attribute || "id"))
+                        .match(o.expression || (/(.+)[-=_](.+)/));
+                        pid = parentItem[2];
+        }
+
+        if (id) {
+          ret.push({
+            "item_id": id[2],
+            "parent_id": pid,
+            "depth": depth,
+            "left": _left,
+            "right": right
+          });
+        }
+
+        _left = right + 1;
+        return _left;
+      }
+
+    },
+
+    _clearEmpty: function (item) {
+      function replaceClass(elem, search, replace, swap) {
+        if (swap) {
+          search = [replace, replace = search][0];
+        }
+
+        $(elem).removeClass(search).addClass(replace);
+      }
+
+      var o = this.options,
+        childrenList = $(item).children(o.listType),
+        hasChildren = childrenList.is(':not(:empty)');
+
+      var doNotClear =
+        o.doNotClear ||
+        hasChildren ||
+        o.protectRoot && $(item)[0] === this.element[0];
+
+      if (o.isTree) {
+        replaceClass(item, o.branchClass, o.leafClass, doNotClear);
+
+        if (doNotClear && hasChildren) {
+          replaceClass(item, o.collapsedClass, o.expandedClass);
+        }
+      }
+
+      if (!doNotClear) {
+        childrenList.remove();
+      }
+    },
+
+    _getLevel: function(item) {
+
+      var level = 1,
+        list;
+
+      if (this.options.listType) {
+        list = item.closest(this.options.listType);
+        while (list && list.length > 0 && !list.is(".ui-sortable")) {
+          level++;
+          list = list.parent().closest(this.options.listType);
+        }
+      }
+
+      return level;
+    },
+
+    _getChildLevels: function(parent, depth) {
+      var self = this,
+        o = this.options,
+        result = 0;
+      depth = depth || 0;
+
+      $(parent).children(o.listType).children(o.items).each(function(index, child) {
+        result = Math.max(self._getChildLevels(child, depth + 1), result);
+      });
+
+      return depth ? result + 1 : result;
+    },
+
+    _isAllowed: function(parentItem, level, levels) {
+      var o = this.options,
+        // this takes into account the maxLevels set to the recipient list
+        maxLevels = this
+      .placeholder
+      .closest(".ui-sortable")
+      .nestedSortable("option", "maxLevels"),
+
+      // Check if the parent has changed to prevent it, when o.disableParentChange is true
+      oldParent = this.currentItem.parent().parent(),
+        disabledByParentchange = o.disableParentChange && (
+          //From somewhere to somewhere else, except the root
+          typeof parentItem !== 'undefined' && !oldParent.is(parentItem) ||
+            typeof parentItem === 'undefined' && oldParent.is("li")	//From somewhere to the root
+      );
+      // mjs - is the root protected?
+      // mjs - are we nesting too deep?
+      if (
+        disabledByParentchange ||
+        !o.isAllowed(this.placeholder, parentItem, this.currentItem)
+      ) {
+        this.placeholder.addClass(o.errorClass);
+        if (maxLevels < levels && maxLevels !== 0) {
+          this.beyondMaxLevels = levels - maxLevels;
+        } else {
+          this.beyondMaxLevels = 1;
+        }
+      } else {
+        if (maxLevels < levels && maxLevels !== 0) {
+          this.placeholder.addClass(o.errorClass);
+          this.beyondMaxLevels = levels - maxLevels;
+        } else {
+          this.placeholder.removeClass(o.errorClass);
+          this.beyondMaxLevels = 0;
+        }
+      }
+    }
+
+  }));
+
+  $.mjs.nestedSortable.prototype.options = $.extend(
+    {},
+    $.ui.sortable.prototype.options,
+    $.mjs.nestedSortable.prototype.options
+  );
+}));


### PR DESCRIPTION
This feature works with the theory that structural metadata can be
abstracted into a hash that looks like the following:

```ruby
{
  "nodes": [
    {
      "label": "Chapter 1",
      "nodes": [
        {
          "proxy": "mcvaa9zja"
        }
      ]
    }
  ]
}
```

This hash is created by the frontend with `StructureParser`, is
converted into an ordered graph by `LogicalOrder`, and can be created
from an ordered graph by `LogicalOrderGraph`.

This hash is also used to create IIIF Manifest Ranges for the viewer.

Closes #225, closes #18.