### PR TITLE
Adding viewing direction/hint - closes #62

### DIFF
--- a/app/assets/javascripts/bulk_label.es6
+++ b/app/assets/javascripts/bulk_label.es6
@@ -17,6 +17,7 @@ class BulkLabeler {
       $(this).data("current-value", $(this).val())
     })
     this.track_radio_buttons()
+    this.track_resource_form()
     this.setup_buttons()
     this.flash = new window.Flash
   }
@@ -52,7 +53,13 @@ class BulkLabeler {
       master.check_save_button()
     })
   }
-
+  track_resource_form() {
+    let master = this
+    this.element.find("input.resource-radio-button").change(function() {
+      $("#resource-form").attr("changed", "true")
+      master.check_save_button()
+    })
+  }
   setup_buttons() {
     this.actions_element.on_apply(this.apply_labels)
     this.actions_element.on_save(this.save_labels)
@@ -106,6 +113,11 @@ class BulkLabeler {
       event.preventDefault()
       this.changed_members.find("form").submit()
       this.selected_elements.removeClass("ui-selected")
+
+      if ($("#resource-form").attr("changed") == "true") {
+        $("#resource-form").submit()
+        $("#resource-form").attr("changed", "false")
+      }
     }
   }
 
@@ -120,7 +132,7 @@ class BulkLabeler {
   }
 
   get needs_saved() {
-    return this.changed_members.length != 0 || this.sorter.needs_saved
+    return this.changed_members.length != 0 || this.sorter.needs_saved || $("#resource-form").attr("changed") == "true"
   }
 
   check_save_button() {

--- a/app/forms/curation_concerns/scanned_resource_form.rb
+++ b/app/forms/curation_concerns/scanned_resource_form.rb
@@ -1,5 +1,6 @@
 module CurationConcerns
   class ScannedResourceForm < ::CurationConcerns::CurationConcernsForm
     self.model_class = ::ScannedResource
+    self.terms += [:viewing_direction, :viewing_hint]
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -21,6 +21,7 @@ class Ability
   def curation_concern_creator_permissions
     # Do not allow creators to destroy what they make.
     can [:create, :read, :edit, :update, :publish], curation_concerns
+    can [:bulk_edit], ScannedResource
     can [:create, :read, :edit, :update, :publish], FileSet
     can [:create, :read, :edit, :update, :publish], Collection
   end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -2,7 +2,7 @@ class SearchBuilder < CurationConcerns::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
 
   def self.show_actions
-    [:show, :manifest, :bulk_edit, :structure]
+    [:show, :manifest, :structure]
   end
 
   def hide_parented_resources(solr_params)

--- a/app/validators/viewing_direction_validator.rb
+++ b/app/validators/viewing_direction_validator.rb
@@ -13,10 +13,10 @@ class ViewingDirectionValidator < ActiveModel::Validator
 
     def valid_viewing_directions
       [
-        ["left-to-right"],
-        ["right-to-left"],
-        ["top-to-bottom"],
-        ["bottom-to-top"]
+        "left-to-right",
+        "right-to-left",
+        "top-to-bottom",
+        "bottom-to-top"
       ]
     end
 end

--- a/app/views/curation_concerns/scanned_resources/_form_rights.html.erb
+++ b/app/views/curation_concerns/scanned_resources/_form_rights.html.erb
@@ -10,3 +10,4 @@
         } %>
     </fieldset>
   </div>
+</div>

--- a/app/views/curation_concerns/scanned_resources/_iiif_fields.html.erb
+++ b/app/views/curation_concerns/scanned_resources/_iiif_fields.html.erb
@@ -1,0 +1,31 @@
+<div class="well">
+  <%= simple_form_for [main_app, curation_concern], remote: true, html: { id: 'resource-form' } do |f| %>
+    <% directions = ['left-to-right', 'right-to-left', 'top-to-bottom', 'bottom-to-top'] %>
+    <% selected_direction = curation_concern.viewing_direction || directions.first %>
+    <div>
+      <label>Viewing Direction:</label>
+      <% directions.each do |val| %>
+        <div class="radio">
+          <%= content_tag :label do %>
+            <%= tag :input, name: "scanned_resource[viewing_direction]", id: "scanned_resource_viewing_direction_#{val}", type: :radio, value: val, checked: (val == selected_direction), class: 'resource-radio-button' %>
+            <%= val %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+    <% hints = ['individuals', 'paged', 'continuous'] %>
+    <% selected_hint = curation_concern.viewing_hint || hints.first %>
+    <div>
+      <label>Viewing Hint:</label>
+      <% hints.each do |val| %>
+        <div class="radio">
+          <%= content_tag :label do %>
+            <%= tag :input, name: "scanned_resource[viewing_hint]", id: "scanned_resource_viewing_hint_#{val}", type: :radio, value: val, checked: (val == selected_hint), class: 'resource-radio-button' %>
+            <%= val %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/curation_concerns/scanned_resources/bulk_edit.html.erb
+++ b/app/views/curation_concerns/scanned_resources/bulk_edit.html.erb
@@ -19,6 +19,9 @@
     <div class="col-xs-12">
       <%= render "bulk_edit_actions" %>
     </div>
+    <div class="col-xs-12">
+      <%= render "iiif_fields" %>
+    </div>
   </div>
   <div class="col-xs-8" id="order-grid">
     <div class="col-xs-12">

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -13,17 +13,6 @@ FactoryGirl.define do
       end
     end
 
-    factory :file_with_work do
-      after(:build) do |file, _evaluator|
-        file.title = ['testfile']
-      end
-      after(:create) do |file, evaluator|
-        if evaluator.content
-          Hydra::Works::UploadFileToFileSet.call(file, evaluator.content)
-        end
-        FactoryGirl.create(:generic_work, user: evaluator.user).ordered_members << file
-      end
-    end
     after(:build) do |file, evaluator|
       file.apply_depositor_metadata(evaluator.user.user_key)
     end

--- a/spec/factories/scanned_resources.rb
+++ b/spec/factories/scanned_resources.rb
@@ -45,5 +45,14 @@ FactoryGirl.define do
         col.update_index
       end
     end
+
+    factory :scanned_resource_with_file do
+      after(:create) do |scanned_resource, evaluator|
+        file = FactoryGirl.create(:file_set, user: evaluator.user)
+        scanned_resource.ordered_members << file
+        scanned_resource.save
+        file.update_index
+      end
+    end
   end
 end

--- a/spec/validators/viewing_direction_validator_spec.rb
+++ b/spec/validators/viewing_direction_validator_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ViewingDirectionValidator do
 
         subject.validate(record)
 
-        expect(errors).to have_received(:add).with(:viewing_direction, :inclusion, allow_blank: true, value: ["bad"])
+        expect(errors).to have_received(:add).with(:viewing_direction, :inclusion, allow_blank: true, value: "bad")
       end
     end
   end
@@ -44,7 +44,7 @@ RSpec.describe ViewingDirectionValidator do
   def build_record(viewing_direction:)
     record = instance_double ScannedResource
     allow(record).to receive(:errors).and_return(errors)
-    allow(record).to receive(:viewing_direction).and_return(Array(viewing_direction))
+    allow(record).to receive(:viewing_direction).and_return(viewing_direction)
     allow(record).to receive(:read_attribute_for_validation).with(:viewing_direction).and_return(record.viewing_direction)
     record
   end

--- a/spec/views/curation_concerns/scanned_resources/bulk_edit.html.erb_spec.rb
+++ b/spec/views/curation_concerns/scanned_resources/bulk_edit.html.erb_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "curation_concerns/scanned_resources/bulk_edit.html.erb" do
       )
     )
   end
+  let(:scanned_resource) { FactoryGirl.build(:scanned_resource) }
   let(:resource) { FactoryGirl.build(:file_set) }
   let(:parent) { FactoryGirl.build(:scanned_resource) }
   let(:parent_presenter) do
@@ -32,6 +33,7 @@ RSpec.describe "curation_concerns/scanned_resources/bulk_edit.html.erb" do
     allow(view).to receive(:blacklight_config).and_return(blacklight_config)
     allow(view).to receive(:search_session).and_return({})
     allow(view).to receive(:current_search_session).and_return(nil)
+    allow(view).to receive(:curation_concern).and_return(scanned_resource)
     render
   end
 
@@ -67,7 +69,7 @@ RSpec.describe "curation_concerns/scanned_resources/bulk_edit.html.erb" do
   end
 
   it "renders a form for each member" do
-    expect(rendered).to have_selector("form", count: members.length)
+    expect(rendered).to have_selector("form", count: members.length + 1)
   end
 
   it "renders an input for titles" do


### PR DESCRIPTION
This gets the job done, but there is some weirdness with the label display that I wasn't able to improve with the various _html options:

![screen shot 2015-12-15 at 11 32 34 am 2](https://cloud.githubusercontent.com/assets/856924/11816718/add46d2a-a31f-11e5-956e-c9c37251653b.png)

I think this is probably related to simple_form doing:

``` html
<span>
  <input/>
  <label>text</label>
</span>
```

But Bootstrap wanting:

``` html
<label>
  <input/>
  text
</label>
```