### PR TITLE
Update scanned resource view and edit pages

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -17,6 +17,7 @@
  */
 
 @import 'curation_concerns';
+@import 'curation_concerns/fileupload';
 
 @import 'abstractions/mixins';
 
@@ -35,6 +36,7 @@
 @import "components/viewer";
 @import "components/sorting";
 @import "components/bulk_label";
+@import "components/fileupload";
 @import "jquery-ui/sortable";
 @import "jquery-ui/selectable";
 @import "browse_everything";

--- a/app/assets/stylesheets/components/bulk_label.scss
+++ b/app/assets/stylesheets/components/bulk_label.scss
@@ -1,11 +1,22 @@
 *[data-action=bulk-label] {
   .actions {
-    border: 1px solid black;
-    padding: 5px;
+    padding: 10px;
     .form-group div {
       padding-left: 0;
     }
   }
+
+  .ui-selectable {
+    padding-left: 0px;
+    padding-right: 0px;
+    margin-top: 61px;
+  }
+
+  .btn-group {
+    margin-bottom: 10px;
+    padding-left: 15px;
+  }
+
   ul {
     list-style-type: none;
     &.grid li {

--- a/app/assets/stylesheets/components/fileupload.scss
+++ b/app/assets/stylesheets/components/fileupload.scss
@@ -1,0 +1,15 @@
+form > .browse-everything,
+.fileupload-buttonbar .btn,
+.fileinput-button {
+  width: 100%;
+}
+
+div {
+  .fileupload-list {
+    min-height: 172px;
+  }
+
+  .fileupload-buttonbar {
+    padding-bottom: 4px;
+  }
+}

--- a/app/helpers/bulk_edit_helper.rb
+++ b/app/helpers/bulk_edit_helper.rb
@@ -1,0 +1,27 @@
+module BulkEditHelper
+  def bulk_edit_page_header
+    h = content_tag(:h1, 'Bulk Edit')
+    h += bulk_edit_breadcrumb
+    h.html_safe
+  end
+
+  def bulk_edit_breadcrumb
+    content_tag(:ul, class: 'breadcrumb') do
+      bulk_edit_parent_work
+    end
+  end
+
+  def bulk_edit_parent_work
+    return '' unless @presenter
+    title = 'Back to Parent'
+    link = content_tag(:a, title,
+                       title: @presenter.id,
+                       href: bulk_edit_parent_path)
+    content_tag(:li, link)
+  end
+
+  def bulk_edit_parent_path
+    Rails.application.routes.url_helpers
+      .curation_concerns_scanned_resource_path(@presenter.id)
+  end
+end

--- a/app/views/curation_concerns/file_sets/show.html.erb
+++ b/app/views/curation_concerns/file_sets/show.html.erb
@@ -1,0 +1,16 @@
+<% provide :page_title, @presenter.page_title %>
+<% provide :page_header do %>
+  <h1>File Details <small><%= @presenter.title %></small></h1>
+<% end %>
+<%= media_display @presenter %>
+<%= render "attributes", curation_concern: @presenter %>
+
+  <div class="form-actions">
+    <%= link_to "Download this File", main_app.download_path(@presenter), class: 'btn btn-default' %>
+    <%= link_to "Back to #{parent.human_readable_type}", parent_path(parent), class: 'btn btn-default' %>
+
+    <% if can? :edit, @presenter.id %>
+      <%= link_to "Edit this File", edit_polymorphic_path([main_app, @presenter]), class: 'btn btn-default'  %>
+      <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
+    <% end %>
+  </div>

--- a/app/views/curation_concerns/file_sets/upload/_form.html.erb
+++ b/app/views/curation_concerns/file_sets/upload/_form.html.erb
@@ -1,0 +1,3 @@
+<%= form_for(FileSet.new, url: main_app.curation_concerns_file_sets_path(parent_id: @presenter.id), html: { multipart: true, id: 'fileupload' }) do |f| %>
+  <%= render partial: 'curation_concerns/file_sets/upload/form_fields', presenter: @presenter, locals: { upload_set_id: ActiveFedora::Noid::Service.new.mint } %>
+<% end %>

--- a/app/views/curation_concerns/file_sets/upload/_form_fields.html.erb
+++ b/app/views/curation_concerns/file_sets/upload/_form_fields.html.erb
@@ -1,0 +1,47 @@
+    <!-- The file upload form used as target for the file upload widget -->
+      <%= hidden_field_tag(:total_upload_size, 0) %>
+      <%= hidden_field_tag(:relative_path) %>
+      <%= hidden_field_tag(:upload_set_id, upload_set_id) %>
+      <%= hidden_field_tag "file_coming_from", "local" %>
+
+      <div class="row">
+        <div class="col-md-3">
+          <div class="well well-sm fileupload-buttonbar">
+            <span class="btn btn-success fileinput-button">
+                <i class="glyphicon glyphicon-plus"></i>
+                <span>Select files...</span>
+                <input type="file" name="file_set[files][]" multiple />
+            </span>
+            <% ua = request.env['HTTP_USER_AGENT'] %>
+            <% if !!(ua =~ /Chrome/) %>
+            <span class="btn btn-success fileinput-button">
+                <i class="glphicon glyphicon-plus"></i>
+                <span>Select folder...</span>
+                <input type="file" name="file_set[files][]" directory webkitdirectory mozdirectory />
+            </span>
+            <% end %>
+            <button type="submit" class="activate-submit btn btn-primary start" id="main_upload_start">
+                <i class="glyphicon glyphicon-upload"></i>
+                <span>Start upload</span>
+            </button>
+            </span>
+            <button type="reset" class="btn btn-warning cancel">
+                <i class="glyphicon glyphicon-ban-circle"></i>
+                <span>Cancel upload</span>
+            </button>
+          </div>
+        </div>
+        <div class="col-md-9 fileupload-progress">
+          <div class="well well-sm fileupload-list">
+            <!-- The global progress bar -->
+            <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+                <div class="progress-bar progress-bar-success" style="width:0%;"></div>
+            </div>
+            <!-- The loading indicator is shown during image processing -->
+            <div class="fileupload-loading"></div>
+            <br />
+            <!-- The table listing the files available for upload/download -->
+            <table id="file-table" class="table table-striped"><tbody class="files" data-toggle="modal-gallery" data-target="#modal-gallery"></tbody></table>
+          </div>
+        </div>
+      </div>

--- a/app/views/curation_concerns/scanned_resources/_bulk_edit_actions.html.erb
+++ b/app/views/curation_concerns/scanned_resources/_bulk_edit_actions.html.erb
@@ -1,4 +1,4 @@
-  <div class="actions form-horizontal">
+  <div class="actions form-horizontal panel panel-default">
     <div class="form-group">
       <%= label_tag "start_with", "Start With:", class: "col-sm-4 control-label" %>
       <div class="col-sm-8">

--- a/app/views/curation_concerns/scanned_resources/_multiple_upload.html.erb
+++ b/app/views/curation_concerns/scanned_resources/_multiple_upload.html.erb
@@ -1,0 +1,3 @@
+<%= render 'curation_concerns/file_sets/upload/alerts', presenter: @presenter %>
+<%= render 'curation_concerns/file_sets/upload/form', presenter: @presenter %>
+<%= render 'curation_concerns/file_sets/upload/script_templates', presenter: @presenter %>

--- a/app/views/curation_concerns/scanned_resources/_server_upload.html.erb
+++ b/app/views/curation_concerns/scanned_resources/_server_upload.html.erb
@@ -1,10 +1,18 @@
-  <div class="well">
-    <%= form_tag polymorphic_path([main_app, :browse_everything_files, @presenter]), id: "browse-everything-form" do %>
-      <%= button_tag type: 'button', class: 'browse-everything btn btn-primary' do %>
-        Upload from Server
+ <div class="row">
+  <div class="col-md-3"> 
+    <div class="well well-sm">
+      <%= form_tag polymorphic_path([main_app, :browse_everything_files, @presenter]), id: "browse-everything-form" do %>
+        <%= button_tag type: 'button', class: 'browse-everything btn btn-primary' do %>
+          Upload from Server
+        <% end %>
       <% end %>
-    <% end %>
-    <% if @presenter.pending_uploads.present? %>
-      <%= render "pending_uploads", uploads: @presenter.pending_uploads %>
-    <% end %>
+    </div>
   </div>
+  <% if @presenter.pending_uploads.present? %>
+    <div class="col-md-9">
+      <div class="well well-sm">
+        <%= render "pending_uploads", uploads: @presenter.pending_uploads %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/curation_concerns/scanned_resources/_show_actions.html.erb
+++ b/app/views/curation_concerns/scanned_resources/_show_actions.html.erb
@@ -1,5 +1,4 @@
 <% if collector || editor %>
-  <%= render "server_upload" %>
   <div class="form-actions">
     <% if editor %>
       <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]), class: 'btn btn-default' %>

--- a/app/views/curation_concerns/scanned_resources/bulk_edit.html.erb
+++ b/app/views/curation_concerns/scanned_resources/bulk_edit.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t("headers.bulk_edit") %></h1>
+<%= bulk_edit_page_header %>
 <div class="flash-message">
   <div class="container">
     <div class="col-md-12">
@@ -11,21 +11,20 @@
   </div>
 </div>
 
+<div class="col-md-12">
+  <h2>Attach Files</h2>
+  <%= render 'multiple_upload', presenter: @presenter %>
+  <%= render "server_upload" %>
+</div>
+
 <div data-action="bulk-label">
-  <div class="col-xs-3">
-    <div class="col-xs-12">
-      <%= link_to "Back to Parent", polymorphic_path([main_app, @presenter]) %>
-    </div>
-    <div class="col-xs-12">
+    <div class="col-md-3">
+      <h2>Label & Order</h2>
       <%= render "bulk_edit_actions" %>
-    </div>
-    <div class="col-xs-12">
       <%= render "iiif_fields" %>
     </div>
-  </div>
-  <div class="col-xs-8" id="order-grid">
-    <div class="col-xs-12">
-      <div class="btn-group col-xs-12" role="group" data-action="list-toggle">
+    <div class="col-md-9" id="order-grid">
+      <div class="btn-group" role="group" data-action="list-toggle">
         <button type="button" class="btn btn-default active list" aria-label="List">
           <span class="glyphicon glyphicon-th-list" aria-hidden="true"></span>
         </button>
@@ -33,11 +32,10 @@
           <span class="glyphicon glyphicon-th" aria-hidden="true"></span>
         </button>
       </div>
+      <ul id="sortable" data-id="<%= @presenter.id %>" class="list-unstyled">
+        <% @members.each do |member| %>
+          <%= render "bulk_edit_member", node: member %>
+        <% end %>
+      </ul>
     </div>
-    <ul id="sortable" data-id="<%= @presenter.id %>" class="list-unstyled col-xs-12">
-      <% @members.each do |member| %>
-        <%= render "bulk_edit_member", node: member %>
-      <% end %>
-    </ul>
-  </div>
 </div>

--- a/app/views/curation_concerns/scanned_resources/show.html.erb
+++ b/app/views/curation_concerns/scanned_resources/show.html.erb
@@ -8,9 +8,5 @@
 
 <%= render 'representative_media', work: @presenter %>
 <%= render 'attributes', curation_concern: @presenter %>
-<%= render 'related_files', presenter: @presenter %>
-<% if editor %>
-  <%= render 'multiple_upload', presenter: @presenter %>
-<% end %>
 
 <%= render "show_actions", collector: collector, editor: editor%>

--- a/spec/features/edit_scanned_resource_spec.rb
+++ b/spec/features/edit_scanned_resource_spec.rb
@@ -3,6 +3,13 @@ require 'rails_helper'
 RSpec.feature "ScannedResourcesController", type: :feature do
   let(:user) { FactoryGirl.create(:curation_concern_creator) }
   let(:scanned_resource) { FactoryGirl.create(:scanned_resource_with_multi_volume_work, user: user) }
+  let(:parent_presenter) do
+    ScannedResourceShowPresenter.new(
+      SolrDocument.new(
+        scanned_resource.to_solr
+      ), nil
+    )
+  end
 
   context "an authorized user" do
     before(:each) do
@@ -40,11 +47,8 @@ RSpec.feature "ScannedResourcesController", type: :feature do
         click_on("Attach to Scanned Resource")
       end
 
-      within '.related_files' do
-        expect(page).to have_link "image.png"
-        click_link "image.png"
-        expect(page).to have_content "image.png"
-      end
+      visit polymorphic_path [parent_presenter.file_presenters.first]
+      expect(page).to have_content "image.png"
     end
   end
 

--- a/spec/helpers/bulk_edit_helper_spec.rb
+++ b/spec/helpers/bulk_edit_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe BulkEditHelper do
+  let(:solr_document) { SolrDocument.new }
+  let(:parent_id) { 'testid' }
+  let(:presenter) { double(solr_document: solr_document,
+                           id: parent_id) }
+  before do
+    assign(:presenter, presenter)
+  end
+
+  describe '#bulk_edit_page_header' do
+    subject { helper.bulk_edit_page_header }
+
+    let(:href) { Rails.application.routes.url_helpers
+      .curation_concerns_scanned_resource_path(parent_id) }
+
+    it { is_expected.to have_link('Back to Parent', href: href) }
+    it { is_expected.to have_selector('ul.breadcrumb') }
+  end
+end

--- a/spec/views/curation_concerns/scanned_resources/_show_actions.html.erb_spec.rb
+++ b/spec/views/curation_concerns/scanned_resources/_show_actions.html.erb_spec.rb
@@ -20,19 +20,4 @@ RSpec.describe "curation_concerns/scanned_resources/_show_actions.html.erb" do
   it "renders an Edit Structure link" do
     expect(rendered).to have_link "Edit Structure", structure_curation_concerns_scanned_resource_path(id: resource.id)
   end
-  it "renders a server upload form" do
-    expect(rendered).to have_selector "form#browse-everything-form"
-    expect(rendered).to have_selector "button.browse-everything"
-  end
-  context "when there are pending uploads" do
-    let(:presenter) do
-      s = ScannedResourceShowPresenter.new(solr_document, nil)
-      allow(s).to receive(:pending_uploads).and_return([pending_upload])
-      s
-    end
-    let(:pending_upload) { FactoryGirl.build(:pending_upload) }
-    it "displays them" do
-      expect(rendered).to have_content pending_upload.file_name
-    end
-  end
 end


### PR DESCRIPTION
This PR:

- removes file upload and member sections from scanned resource
- changes the styling for multiple file uploads
- moves file upload to the bulk editor page

This is a WIP, so comments please. The arrangement on the bulk editor page looks funny. It could use some work. I was thinking that file uploads should go above bulk relabeling. Also, there is no way to delete files now. Perhaps a button on each file 'card' in the label section?
