### PR TITLE
Add link to FileSet show page from bulk editor

### DIFF
--- a/app/assets/stylesheets/components/bulk_label.scss
+++ b/app/assets/stylesheets/components/bulk_label.scss
@@ -56,8 +56,19 @@
         display: inline-block;
       }
       .order-filename {
-        width: 49%;
+        width: 46%;
         display: inline-block;
+      }
+      .file-set-link {
+        display: inline-block;
+        width: 3%;
+        a {
+          font-size: 20px;
+          color: #999;
+        }
+        span {
+          top: 5px;
+        }
       }
       .ui-selecting .panel-body {
         background: #FECA40;

--- a/app/views/curation_concerns/scanned_resources/_bulk_edit_member.html.erb
+++ b/app/views/curation_concerns/scanned_resources/_bulk_edit_member.html.erb
@@ -8,6 +8,11 @@
         <div class="order-filename">
           <em>(<%= node.file_label %>)</em>
         </div>
+        <div class="file-set-link">
+          <%= link_to polymorphic_path([main_app, node]), title: "Edit file" do %>
+            <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
+          <% end %>
+        </div>
       </div>
       <div class="panel-body">
         <div class="text-center thumbnail">

--- a/spec/views/curation_concerns/scanned_resources/bulk_edit.html.erb_spec.rb
+++ b/spec/views/curation_concerns/scanned_resources/bulk_edit.html.erb_spec.rb
@@ -53,6 +53,10 @@ RSpec.describe "curation_concerns/scanned_resources/bulk_edit.html.erb" do
     expect(rendered).to have_content "file_name.tif"
   end
 
+  it "has a link to edit each file set" do
+    expect(rendered).to have_selector('a[href="/concern/file_sets/test"]')
+  end
+
   it "has a link back to parent" do
     expect(rendered).to have_link "Back to Parent", href: curation_concerns_scanned_resource_path(id: "resource")
   end


### PR DESCRIPTION
Adds icon to bulk editor tiles that links to the file set show page for each item. Closes #255.

![screenshot 2015-12-17 13 24 20](https://cloud.githubusercontent.com/assets/784196/11878088/97e49c12-a4c1-11e5-80ec-7b53bced272b.png)
