### PR TITLE
Refactor manifest builder

### DIFF
--- a/app/services/auth_manifest_builder.rb
+++ b/app/services/auth_manifest_builder.rb
@@ -2,21 +2,37 @@
 # @see http://iiif.io/api/auth/0.9/
 class AuthManifestBuilder
   def self.auth_services(login_url, logout_url)
-    {
+    new(
       "@context": "http://iiif.io/api/auth/0/context.json",
       "@id": login_url,
       "label": "Login to Plum using CAS",
       "profile": "http://iiif.io/api/auth/0/login",
       "service": AuthManifestBuilder.logout_service(logout_url)
-    }
+    )
   end
 
   def self.logout_service(logout_url)
-    return [] unless logout_url
-    [{
-      "@id": logout_url,
-      "label": "Logout from Plum",
-      "profile": "http://iiif.io/api/auth/0/logout"
-    }]
+    if logout_url
+      new(
+        [
+          {
+            "@id": logout_url,
+            "label": "Logout from Plum",
+            "profile": "http://iiif.io/api/auth/0/logout"
+          }
+        ]
+      )
+    else
+      new(nil)
+    end
+  end
+
+  attr_reader :hsh
+  def initialize(hsh)
+    @hsh = hsh
+  end
+
+  def apply(manifest)
+    manifest['service'] = hsh if hsh.present?
   end
 end

--- a/app/services/canvas_builder.rb
+++ b/app/services/canvas_builder.rb
@@ -12,7 +12,11 @@ class CanvasBuilder
   end
 
   def path
-    CanvasID.new(record.id, parent_path).to_s
+    CanvasID.new(record.id, parent_path.to_s).to_s
+  end
+
+  def apply(sequence)
+    sequence.canvases += [canvas]
   end
 
   class Canvas < IIIF::Presentation::Canvas
@@ -39,7 +43,7 @@ class CanvasBuilder
       annotation = IIIF::Presentation::Annotation.new
       annotation.resource = image
       annotation["on"] = path
-      annotation["@id"] = parent_path + "/annotation/#{record.id}-image"
+      annotation["@id"] = parent_path.to_s + "/annotation/#{record.id}-image"
       canvas.images << annotation
       canvas.width = image.width
       canvas.height = image.height

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -1,31 +1,54 @@
 class ManifestBuilder
-  attr_reader :record, :light
+  attr_reader :record, :services
   delegate :to_json, to: :manifest
 
-  def initialize(record, light = false, ssl: false, services: nil)
+  def initialize(record, ssl: false, services: nil)
     @record = record
-    @light = light
     @ssl = ssl
-    apply_record_properties
-    manifest['service'] = services if services
+    @services = CompositeBuilder.new(*Array.wrap(services))
+    builders.apply(manifest)
   end
 
   def manifest
     @manifest ||= manifest_builder_class
   end
 
-  def canvases
-    @canvases ||= canvas_builders.map(&:canvas)
+  def manifests
+    @manifests ||= manifest_builders.manifest
   end
 
-  def manifests
-    @manifests ||= manifest_builders.map(&:manifest)
+  def canvases
+    canvas_builders.canvas
+  end
+
+  def root_path
+    @root_path ||= ManifestPath.new(record, ssl: @ssl)
+  end
+
+  def apply(manifest)
+    manifest['manifests'] ||= []
+    manifest['manifests'] += [self.manifest]
   end
 
   private
 
-    def ssl?
-      @ssl == true
+    def builders
+      @builders ||=
+        CompositeBuilder.new(
+          record_property_builder,
+          services,
+          sequence_builder,
+          range_builder,
+          manifest_builders
+        )
+    end
+
+    def record_property_builder
+      RecordPropertyBuilder.new(record, root_path)
+    end
+
+    def sequence_builder
+      SequenceBuilder.new(root_path, canvas_builders)
     end
 
     def manifest_builder_class
@@ -36,83 +59,16 @@ class ManifestBuilder
       end
     end
 
-    def path
-      helper.polymorphic_url([:manifest, record], protocol: protocol)
-    end
-
-    def protocol
-      if ssl?
-        :https
-      else
-        :http
-      end
-    end
-
     def canvas_builders
-      file_set_presenters.map do |generic_file|
-        CanvasBuilder.new(generic_file, path)
-      end
-    end
-
-    def file_set_presenters
-      record.file_presenters.select do |x|
-        x.model_name.name == "FileSet"
-      end
+      @canvas_builders ||= CanvasBuilderFactory.new(record).new(root_path)
     end
 
     def manifest_builders
-      manifest_presenters.map do |model|
-        ManifestBuilder.new(model, true, ssl: ssl?)
-      end
+      @manifest_builders ||= ManifestBuilderFactory.new(record, ssl: @ssl).new
     end
 
-    def manifest_presenters
-      record.file_presenters - file_set_presenters
-    end
-
-    def helper
-      @helper ||= RouteHelper.new
-    end
-
-    class RouteHelper
-      include Rails.application.routes.url_helpers
-      include ActionDispatch::Routing::PolymorphicRoutes
-    end
-
-    def apply_record_properties
-      manifest['@id'] = path
-      manifest.label = record.to_s
-      manifest.description = record.description
-      manifest.viewing_hint = record.viewing_hint || "individuals"
-      if manifest.respond_to?(:viewing_direction)
-        manifest.viewing_direction = record.try(:viewing_direction) || "left-to-right"
-      end
-      apply_extras
-    end
-
-    def apply_extras
-      unless light
-        apply_canvases
-        apply_structures
-      end
-      apply_manifests if manifests.length > 0
-    end
-
-    def apply_canvases
-      return if canvases.length == 0
-      sequence = IIIF::Presentation::Sequence.new
-      sequence["@id"] = path + "/sequence/normal"
-      sequence.viewing_hint = manifest.viewing_hint
-      sequence.canvases += canvases
-      manifest.sequences += [sequence]
-    end
-
-    def apply_manifests
-      manifest['manifests'] = manifests
-    end
-
-    def apply_structures
-      manifest['structures'] = [RangeBuilder.new(logical_order, path, top: true, label: "Logical").to_h]
+    def range_builder
+      RangeBuilder.new(logical_order, root_path, top: true, label: "Logical")
     end
 
     def logical_order

--- a/app/services/manifest_builder/canvas_builder_factory.rb
+++ b/app/services/manifest_builder/canvas_builder_factory.rb
@@ -1,0 +1,24 @@
+class ManifestBuilder
+  class CanvasBuilderFactory
+    attr_reader :record
+    def initialize(record)
+      @record = record
+    end
+
+    def new(root_path)
+      CompositeBuilder.new(
+        *file_set_presenters.map do |generic_file|
+          CanvasBuilder.new(generic_file, root_path)
+        end
+      )
+    end
+
+    private
+
+      def file_set_presenters
+        record.file_presenters.select do |x|
+          x.model_name.name == "FileSet"
+        end
+      end
+  end
+end

--- a/app/services/manifest_builder/child_manifest_builder.rb
+++ b/app/services/manifest_builder/child_manifest_builder.rb
@@ -1,0 +1,7 @@
+class ManifestBuilder
+  class ChildManifestBuilder < ManifestBuilder
+    def builders
+      @builders ||= record_property_builder
+    end
+  end
+end

--- a/app/services/manifest_builder/composite_builder.rb
+++ b/app/services/manifest_builder/composite_builder.rb
@@ -1,0 +1,21 @@
+class ManifestBuilder
+  class CompositeBuilder
+    attr_reader :services
+    delegate :length, to: :services
+    def initialize(*services)
+      @services = services.compact
+    end
+
+    def apply(manifest)
+      services.each do |service|
+        service.apply(manifest)
+      end
+    end
+
+    def method_missing(meth_name, *args, &block)
+      services.map do |service|
+        service.__send__(meth_name, *args, &block)
+      end
+    end
+  end
+end

--- a/app/services/manifest_builder/manifest_builder_factory.rb
+++ b/app/services/manifest_builder/manifest_builder_factory.rb
@@ -1,0 +1,23 @@
+class ManifestBuilder
+  class ManifestBuilderFactory
+    attr_reader :record, :ssl
+    def initialize(record, ssl: false)
+      @record = record
+      @ssl = ssl
+    end
+
+    def new
+      CompositeBuilder.new(
+        *manifest_presenters.map do |model|
+          ChildManifestBuilder.new(model, ssl: @ssl)
+        end
+      )
+    end
+
+    def manifest_presenters
+      record.file_presenters.select do |x|
+        x.model_name.name != "FileSet"
+      end
+    end
+  end
+end

--- a/app/services/manifest_builder/manifest_path.rb
+++ b/app/services/manifest_builder/manifest_path.rb
@@ -1,0 +1,36 @@
+class ManifestBuilder
+  class ManifestPath
+    attr_reader :record, :ssl
+    def initialize(record, ssl: false)
+      @record = record
+      @ssl = ssl
+    end
+
+    def to_s
+      helper.polymorphic_url([:manifest, record], protocol: protocol)
+    end
+
+    private
+
+      def helper
+        @helper ||= RouteHelper.new
+      end
+
+      class RouteHelper
+        include Rails.application.routes.url_helpers
+        include ActionDispatch::Routing::PolymorphicRoutes
+      end
+
+      def ssl?
+        @ssl == true
+      end
+
+      def protocol
+        if ssl?
+          :https
+        else
+          :http
+        end
+      end
+  end
+end

--- a/app/services/manifest_builder/record_property_builder.rb
+++ b/app/services/manifest_builder/record_property_builder.rb
@@ -1,0 +1,28 @@
+class ManifestBuilder
+  class RecordPropertyBuilder
+    attr_reader :record, :path
+    def initialize(record, path, ssl: false)
+      @record = record
+      @path = path
+      @ssl = ssl
+    end
+
+    def apply(manifest)
+      manifest['@id'] = path.to_s
+      manifest.label = record.to_s
+      manifest.description = record.description
+      manifest.viewing_hint = viewing_hint
+      manifest.try(:viewing_direction=, viewing_direction)
+    end
+
+    private
+
+      def viewing_direction
+        record.try(:viewing_direction) || "left-to-right"
+      end
+
+      def viewing_hint
+        record.viewing_hint || "individuals"
+      end
+  end
+end

--- a/app/services/manifest_builder/sequence_builder.rb
+++ b/app/services/manifest_builder/sequence_builder.rb
@@ -1,0 +1,29 @@
+class ManifestBuilder
+  class SequenceBuilder
+    attr_reader :parent_path, :canvas_builder
+    def initialize(parent_path, canvas_builder)
+      @parent_path = parent_path
+      @canvas_builder = canvas_builder
+    end
+
+    def apply(manifest)
+      manifest.sequences += [sequence] unless empty?
+    end
+
+    def empty?
+      sequence.canvases.length == 0
+    end
+
+    private
+
+      def sequence
+        @sequence ||=
+          begin
+            sequence = IIIF::Presentation::Sequence.new
+            sequence["@id"] ||= parent_path.to_s + "/sequence/normal"
+            canvas_builder.apply(sequence)
+            sequence
+          end
+      end
+  end
+end

--- a/app/services/range_builder.rb
+++ b/app/services/range_builder.rb
@@ -15,6 +15,10 @@ class RangeBuilder
     build_range
   end
 
+  def apply(manifest)
+    manifest['structures'] = [to_h]
+  end
+
   private
 
     def build_range

--- a/app/services/range_builder.rb
+++ b/app/services/range_builder.rb
@@ -27,7 +27,7 @@ class RangeBuilder
       range['@id'] = path
       range.viewing_hint = "top" if top
       unless regular_nodes.empty?
-        range['ranges'] = nodes.map { |x| self.class.new(x, parent_path).to_h }
+        range['ranges'] = regular_nodes.map { |x| self.class.new(x, parent_path).to_h }
       end
       unless proxy_nodes.empty?
         range['canvases'] = proxy_nodes.map do |proxy_node|
@@ -50,7 +50,7 @@ class RangeBuilder
     end
 
     def regular_nodes
-      @regular_nodes ||= nodes.select { |x| !x.proxy_for.present? }
+      @regular_nodes ||= nodes.select { |x| !x.proxy_for.present? && x.nodes.length > 0 }
     end
 
     def canvas_id(id)

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -82,6 +82,9 @@ RSpec.describe ManifestBuilder, vcr: { cassette_name: "iiif_manifest" } do
                   "proxy": file_set2.id
                 }
               ]
+            },
+            {
+              "label": "Bla"
             }
           ]
         }

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -31,6 +31,15 @@ RSpec.describe ManifestBuilder, vcr: { cassette_name: "iiif_manifest" } do
       expect(manifest['manifests'].first['label']).to eq solr_document.to_s
       expect(manifest['manifests'].first['@type']).to eq "sc:Manifest"
     end
+    it "doesn't render structures for child manifests" do
+      expect(manifest['manifests'].first['structures']).to eq nil
+    end
+    it "doesn't render canvases for child manifests" do
+      allow(ManifestBuilder::SequenceBuilder).to receive(:new).and_call_original
+
+      expect(manifest['manifests'].first['sequences']).to eq nil
+      expect(ManifestBuilder::SequenceBuilder).to have_received(:new).exactly(1).times
+    end
     context "with SSL on" do
       subject { described_class.new(mvw_document, ssl: true) }
       it "renders collections with HTTPS urls" do
@@ -84,7 +93,6 @@ RSpec.describe ManifestBuilder, vcr: { cassette_name: "iiif_manifest" } do
       let(:first_canvas) { subject.canvases.first }
       let(:manifest_json) { JSON.parse(subject.to_json) }
       it "has two" do
-        expect(subject.canvases.length).to eq 2
         expect(manifest_json["sequences"].first["canvases"].length).to eq 2
       end
       it "has a label" do


### PR DESCRIPTION
This bases the manifest builder on a series of "sub-builders", which actually mutate the manifest it eventually generates. It accepts extra builders through the services parameter, and could be refactored later to accept something like a BuilderFinder, if we find it useful. The common API of Builder#apply(manifest) should lower the churn on this file by a fair bit.