### PR TITLE
Add rollback button to FileSet show page

### DIFF
--- a/app/views/curation_concerns/file_sets/show.html.erb
+++ b/app/views/curation_concerns/file_sets/show.html.erb
@@ -11,6 +11,8 @@
 
     <% if can? :edit, @presenter.id %>
       <%= link_to "Edit this File", edit_polymorphic_path([main_app, @presenter]), class: 'btn btn-default'  %>
+      <%= link_to( 'Rollback', main_app.versions_curation_concerns_file_set_path(@presenter),
+        { class: 'btn btn-default', title: "Rollback to previous version" }) %>
       <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
     <% end %>
   </div>


### PR DESCRIPTION
Restores rollback functionality that was lost when removing the files list from scanned resource.