### PR TITLE
Improve bulk editor sort/label tile layout

### DIFF
--- a/app/assets/stylesheets/components/bulk_label.scss
+++ b/app/assets/stylesheets/components/bulk_label.scss
@@ -31,10 +31,13 @@
         @extend .col-xs-12;
       }
       .order-title {
-        width: 100%;
+        width: 85%;
       }
       .order-filename {
         width: 100%;
+      }
+      .file-set-link {
+        padding-right: 15px;
       }
     }
     li {

--- a/app/views/curation_concerns/scanned_resources/_bulk_edit_member.html.erb
+++ b/app/views/curation_concerns/scanned_resources/_bulk_edit_member.html.erb
@@ -5,13 +5,13 @@
         <div class="order-title">
           <%= f.input :title, as: :string, input_html: { name: "file_set[title][]" }, value: node.to_s, label: false %>
         </div>
-        <div class="order-filename">
-          <em>(<%= node.file_label %>)</em>
-        </div>
-        <div class="file-set-link">
+        <div class="file-set-link pull-right">
           <%= link_to polymorphic_path([main_app, node]), title: "Edit file" do %>
             <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
           <% end %>
+        </div>
+        <div class="order-filename">
+          <em title="<%= node.file_label %>">(<%= truncate(node.file_label, length: 29) %>)</em>
         </div>
       </div>
       <div class="panel-body">


### PR DESCRIPTION
Repositions edit icon so that it is in the upper right corner in both list and grid configuration. Truncates the file name label to avoid issues with long names.

![screenshot 2015-12-18 16 08 32](https://cloud.githubusercontent.com/assets/784196/11908619/bc22b006-a5ab-11e5-8458-916ba22633f3.png)
