### PR TITLE
DO NOT MERGE: Fixing image heights, putting upload tools at the bottom

### DIFF
--- a/app/assets/javascripts/bulk_label.es6
+++ b/app/assets/javascripts/bulk_label.es6
@@ -160,3 +160,26 @@ class BulkLabeler {
     }
   }
 }
+
+$(() => {
+  var tools = $("#label-tools")
+  var pos = tools.position()
+  var maxpos = $(document).outerHeight() - $("#upload-tools").outerHeight() - $("#footer").outerHeight() - tools.outerHeight()
+  $(window).scroll(function() {
+    if ($(window).width() > 979) {
+      var windowpos = $(window).scrollTop()
+      if (windowpos >= pos.top && windowpos < maxpos) {
+        tools.attr("style", "")
+        tools.addClass("fixed")
+        $("#label-tools-spacer").removeClass("fixed")
+      } else if (windowpos >= maxpos) {
+        tools.removeClass("fixed")
+        tools.css({position: "absolute", top: maxpos + "px"})
+      } else {
+        tools.removeClass("fixed")
+      }
+    } else {
+      tools.removeClass("fixed")
+    }
+  })
+})

--- a/app/assets/javascripts/bulk_label.es6
+++ b/app/assets/javascripts/bulk_label.es6
@@ -162,24 +162,15 @@ class BulkLabeler {
 }
 
 $(() => {
-  var tools = $("#label-tools")
-  var pos = tools.position()
-  var maxpos = $(document).outerHeight() - $("#upload-tools").outerHeight() - $("#footer").outerHeight() - tools.outerHeight()
-  $(window).scroll(function() {
-    if ($(window).width() > 979) {
-      var windowpos = $(window).scrollTop()
-      if (windowpos >= pos.top && windowpos < maxpos) {
-        tools.attr("style", "")
-        tools.addClass("fixed")
-        $("#label-tools-spacer").removeClass("fixed")
-      } else if (windowpos >= maxpos) {
-        tools.removeClass("fixed")
-        tools.css({position: "absolute", top: maxpos + "px"})
-      } else {
-        tools.removeClass("fixed")
+  let tools = $("#label-tools")
+  if(tools.length > 0) {
+    tools.affix({
+      offset: {
+        top: $("#label-tools").parent().offset().top,
+        bottom: function() {
+          return $("#upload-tools").outerHeight(true) + $("footer").outerHeight(true)
+        }
       }
-    } else {
-      tools.removeClass("fixed")
-    }
-  })
+    })
+  }
 })

--- a/app/assets/stylesheets/components/bulk_label.scss
+++ b/app/assets/stylesheets/components/bulk_label.scss
@@ -100,4 +100,22 @@
       }
     }
   }
+  #label-tools {
+    @media (max-width: $screen-md-min) {
+      &.affix {
+        position: inherit;
+      }
+    }
+    @media (min-width: $screen-md-min) {
+      &.affix {
+        top: 0;
+        width: 235px;
+      }
+    }
+    @media (min-width: $screen-lg-min) {
+      &.affix {
+        width: 285px;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/components/bulk_label.scss
+++ b/app/assets/stylesheets/components/bulk_label.scss
@@ -17,13 +17,24 @@
     padding-left: 15px;
   }
 
+  .fixed {
+    position: fixed;
+    width: inherit;
+  }
+
   ul {
     list-style-type: none;
     &.grid li {
       @extend .col-xs-4;
       .thumbnail {
         @extend .col-xs-12;
+        padding-bottom: 100%;
+        width: 100%;
       }
+      .thumbnail-inner, .img-responsive {
+        position: absolute; width: 85%;
+      }
+
       .spacer {
         @extend .col-xs-12;
       }

--- a/app/views/curation_concerns/scanned_resources/_bulk_edit_member.html.erb
+++ b/app/views/curation_concerns/scanned_resources/_bulk_edit_member.html.erb
@@ -17,7 +17,7 @@
       <div class="panel-body">
         <div class="text-center thumbnail">
           <%= osd_modal_for(node.id) do %>
-            <%= render_thumbnail_tag node %>
+            <%= render_thumbnail_tag node, class: 'thumbnail-inner' %>
           <% end %>
         </div>
         <div class="attributes">

--- a/app/views/curation_concerns/scanned_resources/bulk_edit.html.erb
+++ b/app/views/curation_concerns/scanned_resources/bulk_edit.html.erb
@@ -1,16 +1,13 @@
 <%= bulk_edit_page_header %>
-<div class="col-md-12">
-  <h2>Attach Files</h2>
-  <%= render 'multiple_upload', presenter: @presenter %>
-  <%= render "server_upload" %>
-</div>
 
-<div data-action="bulk-label">
-    <div class="col-md-3">
+<% if !@members.empty? %>
+  <div data-action="bulk-label">
+    <div class="col-md-3" id="label-tools">
       <h2>Label & Order</h2>
       <%= render "bulk_edit_actions" %>
       <%= render "iiif_fields" %>
     </div>
+    <div class="col-md-3" id="label-tools-spacer" class="fixed"></div>
     <div class="col-md-9" id="order-grid">
       <div class="btn-group" role="group" data-action="list-toggle">
         <button type="button" class="btn btn-default list" aria-label="List">
@@ -26,4 +23,11 @@
         <% end %>
       </ul>
     </div>
+  </div>
+<% end %>
+
+<div class="col-md-12" id="upload-tools">
+  <h2>Attach Files</h2>
+  <%= render 'multiple_upload', presenter: @presenter %>
+  <%= render "server_upload" %>
 </div>


### PR DESCRIPTION
This is a stab at making the grid heights the same for the portait/landscape/placholder images, and making the pagination tools stay on screen.  But there is some weirdness about the width of the pagination tools that needs some tweaking, esp. at narrower page widths.

Closes #302
Closes #303