### PR TITLE
Redirect to ScannedResources in context when created inside a MultiVolumeWork

### DIFF
--- a/app/controllers/curation_concerns/scanned_resources_controller.rb
+++ b/app/controllers/curation_concerns/scanned_resources_controller.rb
@@ -79,4 +79,12 @@ class CurationConcerns::ScannedResourcesController < CurationConcerns::CurationC
     def pdf_path
       PairtreeDerivativePath.derivative_path_for_reference(presenter, 'pdf')
     end
+
+    def after_create_response
+      dest = parent_id.nil? ? polymorphic_path([main_app, curation_concern]) : main_app.curation_concerns_member_scanned_resource_path(parent_id, curation_concern)
+      respond_to do |wants|
+        wants.html { redirect_to dest }
+        wants.json { render :show, status: :created, location: dest }
+      end
+    end
 end

--- a/spec/features/edit_multi_volume_work_spec.rb
+++ b/spec/features/edit_multi_volume_work_spec.rb
@@ -39,6 +39,7 @@ RSpec.feature "MultiVolumeWorksController", type: :feature do
     select 'Marquand', from: 'scanned_resource_access_policy'
     select 'Marquand', from: 'scanned_resource_use_and_reproduction'
     click_button 'Create Scanned resource'
+    expect(current_path).to start_with "/concern/container/#{multi_volume_work.id}/scanned_resources/"
 
     visit polymorphic_path [multi_volume_work]
     expect(page).to have_link('Volume 1', count: 1)


### PR DESCRIPTION
Closes #273