### PR TITLE
Sammelband Manifests

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -30,7 +30,7 @@ class CollectionsController < ApplicationController
   private
 
     def manifest_builder
-      ManifestBuilder.new(presenter, ssl: request.ssl?, services: AuthManifestBuilder.auth_services(login_url, logout_url))
+      PolymorphicManifestBuilder.new(presenter, ssl: request.ssl?, services: AuthManifestBuilder.auth_services(login_url, logout_url))
     end
 
     def all_manifests_builder

--- a/app/controllers/curation_concerns/curation_concerns_controller.rb
+++ b/app/controllers/curation_concerns/curation_concerns_controller.rb
@@ -100,7 +100,7 @@ class CurationConcerns::CurationConcernsController < ApplicationController
     end
 
     def manifest_builder
-      ManifestBuilder.new(presenter, ssl: request.ssl?, services: AuthManifestBuilder.auth_services(login_url, logout_url))
+      PolymorphicManifestBuilder.new(presenter, ssl: request.ssl?, services: AuthManifestBuilder.auth_services(login_url, logout_url))
     end
 
     def login_url

--- a/app/presenters/multi_volume_work_show_presenter.rb
+++ b/app/presenters/multi_volume_work_show_presenter.rb
@@ -1,9 +1,20 @@
 class MultiVolumeWorkShowPresenter < CurationConcernsShowPresenter
   def file_presenter_class
-    ::ScannedResourceShowPresenter
+    DynamicShowPresenter.new
   end
 
   def viewing_hint
     'multi-part'
+  end
+
+  class DynamicShowPresenter
+    def new(*args)
+      solr_doc = args.first
+      if solr_doc.fetch("active_fedora_model_ssi") == "ScannedResource"
+        ScannedResourceShowPresenter.new(*args)
+      else
+        FileSetPresenter.new(*args)
+      end
+    end
   end
 end

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -75,7 +75,11 @@ class ManifestBuilder
     end
 
     def canvas_builders
-      @canvas_builders ||= CanvasBuilderFactory.new(record).new(root_path)
+      @canvas_builders ||= canvas_builder_factory.new(record).new(root_path)
+    end
+
+    def canvas_builder_factory
+      ::ManifestBuilder::CanvasBuilderFactory
     end
 
     def manifest_builders

--- a/app/services/manifest_builder/pdf_link_builder.rb
+++ b/app/services/manifest_builder/pdf_link_builder.rb
@@ -9,6 +9,7 @@ class ManifestBuilder
     def apply(manifest)
       return if record.file_presenters.length == 0
       return if manifest['sequences'].blank?
+      return unless path
       manifest['sequences'].first['rendering'] = {
         '@id' => path,
         'label' => label,
@@ -20,6 +21,8 @@ class ManifestBuilder
 
       def path
         helper.polymorphic_url([:pdf, record], protocol: protocol)
+      rescue
+        nil
       end
 
       def helper

--- a/app/services/polymorphic_manifest_builder.rb
+++ b/app/services/polymorphic_manifest_builder.rb
@@ -1,0 +1,21 @@
+class PolymorphicManifestBuilder
+  class << self
+    def new(solr_document, *args)
+      if solr_document.file_presenters.map(&:class).uniq.length > 1
+        sammelband_manifest_builder.new(solr_document, *args)
+      else
+        manifest_builder.new(solr_document, *args)
+      end
+    end
+
+    private
+
+      def manifest_builder
+        ManifestBuilder
+      end
+
+      def sammelband_manifest_builder
+        SammelbandManifestBuilder
+      end
+  end
+end

--- a/app/services/sammelband_manifest_builder.rb
+++ b/app/services/sammelband_manifest_builder.rb
@@ -13,6 +13,33 @@ class SammelbandManifestBuilder < ManifestBuilder
       @manifest_builders ||= CompositeBuilder.new
     end
 
+    def logical_order
+      @logical_order ||= LogicalOrder.new(combined_logical_order)
+    end
+
+    def combined_logical_order
+      range_presenters.each_with_object("nodes" => []) do |presenter, hsh|
+        hsh["nodes"] << {
+          "label" => presenter.to_s,
+          "nodes" => (presenter.logical_order["nodes"] || canvas_ids(presenter))
+        }
+      end
+    end
+
+    def canvas_ids(presenter)
+      presenter.file_presenters.map do |file_presenter|
+        {
+          "proxy" => file_presenter.id
+        }
+      end
+    end
+
+    def range_presenters
+      record.file_presenters.select do |presenter|
+        !presenter.try(:logical_order).nil?
+      end
+    end
+
     class SammelbandViewingHint < SimpleDelegator
       def viewing_hint
         "individuals"

--- a/app/services/sammelband_manifest_builder.rb
+++ b/app/services/sammelband_manifest_builder.rb
@@ -1,0 +1,21 @@
+class SammelbandManifestBuilder < ManifestBuilder
+  def record
+    @decorated_record ||= SammelbandViewingHint.new(super)
+  end
+
+  private
+
+    def canvas_builder_factory
+      ::SammelbandManifestBuilder::SammelbandCanvasBuilderFactory
+    end
+
+    def manifest_builders
+      @manifest_builders ||= CompositeBuilder.new
+    end
+
+    class SammelbandViewingHint < SimpleDelegator
+      def viewing_hint
+        "individuals"
+      end
+    end
+end

--- a/app/services/sammelband_manifest_builder/sammelband_canvas_builder_factory.rb
+++ b/app/services/sammelband_manifest_builder/sammelband_canvas_builder_factory.rb
@@ -1,0 +1,13 @@
+class SammelbandManifestBuilder
+  class SammelbandCanvasBuilderFactory < ::ManifestBuilder::CanvasBuilderFactory
+    def file_set_presenters
+      record.file_presenters.flat_map do |presenter|
+        if presenter.respond_to?(:file_presenters)
+          presenter.file_presenters
+        else
+          presenter
+        end
+      end
+    end
+  end
+end

--- a/app/values/scanned_resource_pdf.rb
+++ b/app/values/scanned_resource_pdf.rb
@@ -17,6 +17,6 @@ class ScannedResourcePDF
   end
 
   def manifest_builder
-    @manifest_builder ||= ManifestBuilder.new(scanned_resource)
+    @manifest_builder ||= PolymorphicManifestBuilder.new(scanned_resource)
   end
 end

--- a/spec/cassettes/iiif_manifest.yml
+++ b/spec/cassettes/iiif_manifest.yml
@@ -4194,4 +4194,49 @@ http_interactions:
         t0q0Y1x0qpJGu84FNIA7VbihQpnHNKI09KVlAU4FQwcyc0txw3Ff/9k=
     http_version: 
   recorded_at: Mon, 04 Jan 2016 20:01:58 GMT
+- request:
+    method: get
+    uri: http://192.168.99.100:5004/x6%2F33%2Ff1%2F04%2Fo-intermediate_file.jp2/info.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Link:
+      - <http://iiif.io/api/image/2/level2.json>;rel="profile",<http://iiif.io/api/image/2/context.json>;rel="http://www.w3.org/ns/json-ld#context";type="application/ld+json"
+      Access-Control-Allow-Origin:
+      - "*"
+      Last-Modified:
+      - Thu, 10 Sep 2015 23:12:15 GMT
+      Content-Length:
+      - '727'
+      Server:
+      - Werkzeug/0.10.4 Python/2.7.8
+      Date:
+      - Thu, 10 Sep 2015 23:42:13 GMT
+    body:
+      encoding: UTF-8
+      string: '{"profile": ["http://iiif.io/api/image/2/level2.json", {"supports":
+        ["canonicalLinkHeader", "profileLinkHeader", "mirroring", "rotationArbitrary",
+        "sizeAboveFull"], "qualities": ["default", "bitonal", "gray", "color"], "formats":
+        ["jpg", "png", "gif", "webp"]}], "tiles": [{"width": 1024, "scaleFactors":
+        [1, 2, 4, 8, 16, 32, 64]}], "protocol": "http://iiif.io/api/image", "sizes":
+        [{"width": 4, "height": 5}, {"width": 7, "height": 9}, {"width": 13, "height":
+        18}, {"width": 25, "height": 36}, {"width": 50, "height": 72}, {"width": 100,
+        "height": 144}, {"width": 200, "height": 287}], "height": 287, "width": 200,
+        "@context": "http://iiif.io/api/image/2/context.json", "@id": "http://192.168.99.100:5004/x633f104o%2Fjp2.jp2"}'
+    http_version: 
+  recorded_at: Thu, 10 Sep 2015 23:42:14 GMT
 recorded_with: VCR 2.9.3

--- a/spec/presenters/multi_volume_work_show_presenter_spec.rb
+++ b/spec/presenters/multi_volume_work_show_presenter_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe MultiVolumeWorkShowPresenter do
+  subject { described_class.new(solr_doc, nil) }
+  let(:solr_doc) { SolrDocument.new(resource.to_solr) }
+  let(:resource) { FactoryGirl.build(:multi_volume_work) }
+  describe "#file_presenters" do
+    context "when the resource has both scanned resources and filesets" do
+      before do
+        resource.ordered_members << FactoryGirl.create(:file_set)
+        resource.ordered_members << FactoryGirl.create(:scanned_resource)
+        resource.save
+      end
+      it "returns appropriate presenters for both" do
+        expect(subject.file_presenters.map(&:class)).to contain_exactly(ScannedResourceShowPresenter, FileSetPresenter)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements manifests for resources which have both canvases (IE cover pages) AND child scanned resources. This allows MVWs to be Sammelbands. Whether we want to make a Sammelband model is now up to if we need a new workflow or not.