### PR TITLE
Send Events to RabbitMQ for create/update/delete.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,7 @@ gem 'aasm'
 gem 'newrelic_rpm'
 gem 'iso-639'
 gem 'jettywrapper'
+gem 'bunny'
 source 'https://rails-assets.org' do
   gem 'rails-assets-babel-polyfill'
   gem 'rails-assets-bootstrap-select', '1.9.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     afm (0.2.2)
+    amq-protocol (2.0.1)
     arel (6.0.3)
     ast (2.1.0)
     astrolabe (1.3.1)
@@ -235,6 +236,8 @@ GEM
     bootstrap_form (2.3.0)
     breadcrumbs_on_rails (2.3.1)
     builder (3.2.2)
+    bunny (2.2.2)
+      amq-protocol (>= 2.0.1)
     byebug (5.0.0)
       columnize (= 0.9.0)
     cancancan (1.13.1)
@@ -816,6 +819,7 @@ DEPENDENCIES
   active-fedora!
   activefedora-aggregation!
   browse-everything!
+  bunny
   capistrano-passenger
   capistrano-rails
   capistrano-rails-console

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@
     * Version 3.04 is required. You can install it on Mac OSX with `brew install
       tesseract --with-all-languages` For Ubuntu you'll have to
       [compile](https://github.com/tesseract-ocr/tesseract/wiki/Compiling) it.
+* [RabbitMQ](https://www.rabbitmq.com/) (Optional)
+    * Start with rabbitmq-server
+    * Used for publishing create/update/delete events for systems such as 
+      [Pomegranate](https://github.com/pulibrary/pomegranate)
 
 ## Running the Code
 

--- a/app/actors/curation_concerns/multi_volume_work_actor.rb
+++ b/app/actors/curation_concerns/multi_volume_work_actor.rb
@@ -1,7 +1,6 @@
 # Generated via
 #  `rails generate curation_concerns:work MultiVolumeWork`
 module CurationConcerns
-  class MultiVolumeWorkActor < CurationConcerns::BaseActor
-    include ::CurationConcerns::WorkActorBehavior
+  class MultiVolumeWorkActor < PlumActor
   end
 end

--- a/app/actors/curation_concerns/plum_actor.rb
+++ b/app/actors/curation_concerns/plum_actor.rb
@@ -1,0 +1,16 @@
+module CurationConcerns
+  class PlumActor < CurationConcerns::BaseActor
+    include ::CurationConcerns::WorkActorBehavior
+    def update
+      super.tap do |result|
+        messenger.record_updated(curation_concern) if result
+      end
+    end
+
+    private
+
+      def messenger
+        @messenger ||= ManifestEventGenerator.new(Plum.messaging_client)
+      end
+  end
+end

--- a/app/actors/curation_concerns/scanned_resource_actor.rb
+++ b/app/actors/curation_concerns/scanned_resource_actor.rb
@@ -1,7 +1,6 @@
 # Generated via
 #  `rails generate curation_concerns:work ScannedResource`
 module CurationConcerns
-  class ScannedResourceActor < CurationConcerns::BaseActor
-    include ::CurationConcerns::WorkActorBehavior
+  class ScannedResourceActor < PlumActor
   end
 end

--- a/app/actors/file_set_actor.rb
+++ b/app/actors/file_set_actor.rb
@@ -1,0 +1,13 @@
+class FileSetActor < ::CurationConcerns::FileSetActor
+  def attach_file_to_work(*args)
+    super.tap do |result|
+      messenger.record_updated(args.first) if result
+    end
+  end
+
+  private
+
+    def messenger
+      @messenger ||= ManifestEventGenerator.new(Plum.messaging_client)
+    end
+end

--- a/app/controllers/curation_concerns/curation_concerns_controller.rb
+++ b/app/controllers/curation_concerns/curation_concerns_controller.rb
@@ -16,6 +16,11 @@ class CurationConcerns::CurationConcernsController < ApplicationController
     super
   end
 
+  def destroy
+    messenger.record_deleted(curation_concern)
+    super
+  end
+
   def flag
     curation_concern.state = 'flagged'
     note = params[curation_concern_name][:workflow_note]
@@ -40,7 +45,20 @@ class CurationConcerns::CurationConcernsController < ApplicationController
     redirect_to polymorphic_path([main_app, :file_manager, curation_concern])
   end
 
+  def after_create_response
+    send_record_created
+    super
+  end
+
+  def send_record_created
+    messenger.record_created(curation_concern)
+  end
+
   private
+
+    def messenger
+      @messenger ||= ManifestEventGenerator.new(Plum.messaging_client)
+    end
 
     def curation_concern
       @decorated_concern ||=

--- a/app/controllers/curation_concerns/file_sets_controller.rb
+++ b/app/controllers/curation_concerns/file_sets_controller.rb
@@ -21,5 +21,11 @@ module CurationConcerns
       file_attributes = ::FileSetEditForm.model_attributes(attributes)
       actor.update_metadata(file_attributes)
     end
+
+    protected
+
+      def actor
+        @actor ||= ::FileSetActor.new(@file_set, current_user)
+      end
   end
 end

--- a/app/controllers/curation_concerns/scanned_resources_controller.rb
+++ b/app/controllers/curation_concerns/scanned_resources_controller.rb
@@ -36,6 +36,7 @@ class CurationConcerns::ScannedResourcesController < CurationConcerns::CurationC
     end
 
     def after_create_response
+      send_record_created
       dest = parent_id.nil? ? polymorphic_path([main_app, curation_concern]) : main_app.curation_concerns_member_scanned_resource_path(parent_id, curation_concern)
       respond_to do |wants|
         wants.html { redirect_to dest }

--- a/app/services/manifest_event_generator.rb
+++ b/app/services/manifest_event_generator.rb
@@ -1,0 +1,48 @@
+class ManifestEventGenerator
+  attr_reader :rabbit_exchange
+  def initialize(rabbit_exchange)
+    @rabbit_exchange = rabbit_exchange
+  end
+
+  def record_created(record)
+    publish_message(
+      message_with_collections("CREATED", record)
+    )
+  end
+
+  def record_deleted(record)
+    publish_message(
+      message("DELETED", record)
+    )
+  end
+
+  def record_updated(record)
+    publish_message(
+      message_with_collections("UPDATED", record)
+    )
+  end
+
+  private
+
+    def message(type, record)
+      {
+        "id" => record.id,
+        "event" => type,
+        "manifest_url" => helper.polymorphic_url([:manifest, :curation_concerns, record.model_name.singular.to_sym], id: record.id)
+      }
+    end
+
+    def message_with_collections(type, record)
+      message(type, record).merge(
+        "collection_slugs" => record.in_collections.map(&:exhibit_id)
+      )
+    end
+
+    def publish_message(message)
+      rabbit_exchange.publish(message.to_json)
+    end
+
+    def helper
+      @helper ||= ManifestBuilder::ManifestHelper.new
+    end
+end

--- a/app/services/messaging_client.rb
+++ b/app/services/messaging_client.rb
@@ -1,0 +1,26 @@
+class MessagingClient
+  attr_reader :amqp_url
+  def initialize(amqp_url)
+    @amqp_url = amqp_url
+  end
+
+  def publish(message)
+    exchange.publish(message, persistent: true)
+  rescue
+    Rails.logger.warn "Unable to publish message to #{amqp_url}"
+  end
+
+  private
+
+    def bunny_client
+      @bunny_client ||= Bunny.new(amqp_url).tap(&:start)
+    end
+
+    def channel
+      @channel ||= bunny_client.create_channel
+    end
+
+    def exchange
+      @exchange ||= channel.fanout(Plum.config['events']['exchange'], durable: true)
+    end
+end

--- a/config/config.yml
+++ b/config/config.yml
@@ -33,6 +33,9 @@ defaults: &defaults
       ORGgen_plt=yes 
       ORGtparts=R 
       Stiles=\{1024,1024\}
+  events:
+    server: 'amqp://localhost:5672'
+    exchange: 'plum_events'
 
 development:
   <<: *defaults

--- a/config/initializers/plum_config.rb
+++ b/config/initializers/plum_config.rb
@@ -3,13 +3,17 @@ module Plum
     @config ||= config_yaml.with_indifferent_access
   end
 
+  def messaging_client
+    MessagingClient.new(Plum.config['events']['server'])
+  end
+
   private
 
     def config_yaml
       YAML.load(ERB.new(File.read("#{Rails.root}/config/config.yml")).result)[Rails.env]
     end
 
-    module_function :config, :config_yaml
+    module_function :config, :config_yaml, :messaging_client
 end
 
 Hydra::Derivatives.kdu_compress_recipes = Plum.config['jp2_recipes']

--- a/spec/controllers/curation_concerns/file_sets_controller_spec.rb
+++ b/spec/controllers/curation_concerns/file_sets_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe CurationConcerns::FileSetsController do
   let(:file_set) { FactoryGirl.build(:file_set) }
   let(:parent) { FactoryGirl.create(:scanned_resource) }
   let(:user) { FactoryGirl.create(:admin) }
+  let(:file) { fixture_file_upload("files/color.tif", "image/tiff") }
   describe "#update" do
     before do
       sign_in user
@@ -18,6 +19,25 @@ RSpec.describe CurationConcerns::FileSetsController do
       allow_any_instance_of(described_class).to receive(:parent).and_return(parent)
       patch :update, id: file_set.id, file_set: { viewing_hint: 'non-paged' }
       expect(response).to redirect_to(Rails.application.class.routes.url_helpers.file_manager_curation_concerns_scanned_resource_path(parent.id))
+    end
+  end
+
+  describe "#create" do
+    before do
+      sign_in user
+    end
+    it "sends an update message for the parent" do
+      manifest_generator = instance_double(ManifestEventGenerator, record_updated: true)
+      allow(ManifestEventGenerator).to receive(:new).and_return(manifest_generator)
+      allow(IngestFileJob).to receive(:perform_later).and_return(true)
+      allow(CharacterizeJob).to receive(:perform_later).and_return(true)
+      xhr :post, :create, parent_id: parent,
+                          file_set: { files: [file],
+                                      title: ['test title'],
+                                      visibility: 'restricted' }
+
+      expect(FileSet.all.length).to eq 1
+      expect(manifest_generator).to have_received(:record_updated).with(parent)
     end
   end
 end

--- a/spec/services/manifest_event_generator_spec.rb
+++ b/spec/services/manifest_event_generator_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe ManifestEventGenerator do
+  subject { described_class.new(rabbit_connection) }
+  let(:rabbit_connection) { instance_double(MessagingClient, publish: true) }
+  let(:record) { FactoryGirl.build(:scanned_resource) }
+  describe "#record_created" do
+    it "publishes a persistent JSON message" do
+      record.save
+      expected_result = {
+        "id" => record.id,
+        "event" => "CREATED",
+        "manifest_url" => "http://plum.com/concern/scanned_resources/#{record.id}/manifest",
+        "collection_slugs" => []
+      }
+
+      subject.record_created(record)
+
+      expect(rabbit_connection).to have_received(:publish).with(expected_result.to_json)
+    end
+    it "embeds collection memberships" do
+      record.save!
+      collection = FactoryGirl.create(:collection, ordered_members: [record])
+      expected_result = {
+        "id" => record.id,
+        "event" => "CREATED",
+        "manifest_url" => "http://plum.com/concern/scanned_resources/#{record.id}/manifest",
+        "collection_slugs" => [collection.exhibit_id]
+      }
+
+      subject.record_created(record)
+
+      expect(rabbit_connection).to have_received(:publish).with(expected_result.to_json)
+    end
+  end
+
+  describe "#record_deleted" do
+    it "publishes a persistent JSON message" do
+      record.save
+      record.destroy
+      expected_result = {
+        "id" => record.id,
+        "event" => "DELETED",
+        "manifest_url" => "http://plum.com/concern/scanned_resources/#{record.id}/manifest"
+      }
+
+      subject.record_deleted(record)
+
+      expect(rabbit_connection).to have_received(:publish).with(expected_result.to_json)
+    end
+  end
+
+  describe "#record_updated" do
+    it "publishes a persistent JSON message with collection memberships" do
+      record.save!
+      collection = FactoryGirl.create(:collection, ordered_members: [record])
+      expected_result = {
+        "id" => record.id,
+        "event" => "UPDATED",
+        "manifest_url" => "http://plum.com/concern/scanned_resources/#{record.id}/manifest",
+        "collection_slugs" => [collection.exhibit_id]
+      }
+
+      subject.record_updated(record)
+
+      expect(rabbit_connection).to have_received(:publish).with(expected_result.to_json)
+    end
+  end
+end

--- a/spec/services/messaging_client_spec.rb
+++ b/spec/services/messaging_client_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe MessagingClient do
+  subject { described_class.new(url) }
+  let(:url) { "amqp://test.x.z.s:4000" }
+  describe "#publish" do
+    context "when the URL is bad" do
+      it "doesn't error" do
+        expect { subject.publish("testing") }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/support/messaging_client_stub.rb
+++ b/spec/support/messaging_client_stub.rb
@@ -1,0 +1,6 @@
+RSpec.configure do |config|
+  config.before(:each) do
+    messaging_client = instance_double(MessagingClient, publish: true)
+    allow(Plum).to receive(:messaging_client).and_return(messaging_client)
+  end
+end


### PR DESCRIPTION
Allows for Pomegranate to stay up to date with changes in Plum.