### PR TITLE
Display all metadata in schema.

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -77,4 +77,12 @@ class SolrDocument
   def ocr_language
     self[Solrizer.solr_name('ocr_language')]
   end
+
+  def method_missing(meth_name, *args, &block)
+    if ScannedResource.properties.values.map(&:term).include?(meth_name)
+      self[Solrizer.solr_name(meth_name.to_s)]
+    else
+      super
+    end
+  end
 end

--- a/app/presenters/collection_show_presenter.rb
+++ b/app/presenters/collection_show_presenter.rb
@@ -1,6 +1,10 @@
 class CollectionShowPresenter < CurationConcerns::CollectionPresenter
   include CurationConcerns::Serializers
-  delegate :id, :title, :exhibit_id, to: :solr_document
+  delegate :id, :title, :exhibit_id, to: :solr_document, allow_nil: true
+
+  delegate :title, :description, :creator, :contributor, :subject, :publisher, :language,
+           :embargo_release_date, :lease_expiration_date, :rights, to: :solr_document,
+                                                                   allow_nil: true
 
   def file_presenters
     @file_sets ||= CurationConcerns::PresenterFactory.build_presenters(ordered_ids,

--- a/app/presenters/curation_concerns_show_presenter.rb
+++ b/app/presenters/curation_concerns_show_presenter.rb
@@ -1,6 +1,7 @@
 class CurationConcernsShowPresenter < CurationConcerns::WorkShowPresenter
   delegate :date_created, :viewing_hint, :viewing_direction, :state, :type, :identifier, :workflow_note, :logical_order, :logical_order_object, :ocr_language, to: :solr_document
   delegate :flaggable?, to: :state_badge_instance
+  delegate(*ScannedResource.properties.values.map(&:term), to: :solr_document, allow_nil: true)
 
   def state_badge
     state_badge_instance.render

--- a/app/schemas/plum_schema.rb
+++ b/app/schemas/plum_schema.rb
@@ -282,5 +282,12 @@ class PlumSchema < ActiveTriples::Schema
   property :writer_of_supplementary_textual_content, predicate: RDF::Vocab::MARCRelators.wst
   property :writer_of_introduction, predicate: RDF::Vocab::MARCRelators.win
   property :writer_of_preface, predicate: RDF::Vocab::MARCRelators.wpr
+
+  # All of the fields to display when looping through Plum's schema.
+  # Ignore things like admin data (workflow note), title, description, etc, as
+  # those have custom display logic.
+  def self.display_fields
+    ScannedResource.properties.values.map(&:term) - [:description, :state, :rights_statement, :holding_location, :title, :depositor, :source_metadata_identifier, :source_metadata, :date_modified, :date_uploaded, :workflow_note] - IIIFBookSchema.properties.map(&:name)
+  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/services/manifest_builder/metadata_builder.rb
+++ b/app/services/manifest_builder/metadata_builder.rb
@@ -20,11 +20,7 @@ class ManifestBuilder
       end
 
       def metadata_fields
-        [
-          :creator,
-          :date_created,
-          :exhibit_id
-        ]
+        PlumSchema.display_fields + [:exhibit_id]
       end
 
       class MetadataObject

--- a/app/views/curation_concerns/base/_attributes.html.erb
+++ b/app/views/curation_concerns/base/_attributes.html.erb
@@ -5,6 +5,9 @@
   </thead>
   <tbody>
   <%= @presenter.attribute_to_html(:creator, catalog_search_link: true ) %>
+  <% (PlumSchema.display_fields - [:creator]).each do |display_field| %>
+    <%= @presenter.attribute_to_html(display_field) %>
+  <% end %>
   <%= @presenter.attribute_to_html(:date_created) %>
   <tr>
     <th>Access Rights</th>

--- a/spec/services/polymorphic_manifest_builder_spec.rb
+++ b/spec/services/polymorphic_manifest_builder_spec.rb
@@ -250,6 +250,15 @@ RSpec.describe PolymorphicManifestBuilder, vcr: { cassette_name: "iiif_manifest"
           ]
         )
       end
+      it "can do authors" do
+        record.author = ["Test Author"]
+        expect(result.metadata.first).to eql(
+          "label" => "Author",
+          "value" => [
+            "Test Author"
+          ]
+        )
+      end
       it "is empty with no metadata" do
         expect(result.metadata).to be_empty
       end

--- a/spec/views/curation_concerns/base/_attributes.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_attributes.html.erb_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "curation_concerns/base/_attributes.html.erb" do
     SolrDocument.new(
       active_fedora_model_ssi: 'ScannedResource',
       creator_tesim: creator,
+      author_tesim: 'Baggins',
       date_created_tesim: date_created,
       rights_statement_tesim: rights_statement,
       workflow_note_tesim: workflow_note
@@ -31,6 +32,10 @@ RSpec.describe "curation_concerns/base/_attributes.html.erb" do
 
   it "displays creator" do
     assert_catalog_link('creator', creator)
+  end
+
+  it "displays metadata in plum schema" do
+    expect(rendered).to have_content 'Baggins'
   end
 
   it "displays the label for the rights URI" do


### PR DESCRIPTION
This shows all defined metadata in both the Manifest and the Show view.

Closes #197, closes #192