### PR TITLE
Moving minter statefile to logs directory

### DIFF
--- a/config/initializers/curation_concerns.rb
+++ b/config/initializers/curation_concerns.rb
@@ -36,6 +36,9 @@ CurationConcerns.configure do |config|
   # Specify a different template for your repository's NOID IDs
   # config.noid_template = ".reeddeeddk"
 
+  # Specify the minter statefile
+  config.minter_statefile = 'log/minter-state'
+
   # Specify the prefix for Redis keys:
   # config.redis_namespace = "curation_concerns"
 


### PR DESCRIPTION
Locally, this will result in a new minter statefile unless you manually copy it from /tmp.  On hydra-dev, this will use the shared logs directory which is preserved across deploys (and I have copied the statefile from /tmp already, so this will continue where that left off).

Closes #497