### PR TITLE
Color pdf toggle

### DIFF
--- a/app/controllers/curation_concerns/scanned_resources_controller.rb
+++ b/app/controllers/curation_concerns/scanned_resources_controller.rb
@@ -33,8 +33,20 @@ class CurationConcerns::ScannedResourcesController < CurationConcerns::CurationC
   private
 
     def authorize_pdf
-      return unless params[:pdf_quality] == "color"
-      return if can?(:color_pdf, ScannedResource)
+      if params[:pdf_quality] == "color"
+        authorize_color_pdf
+      else
+        authorize_gray_pdf
+      end
+    end
+
+    def authorize_color_pdf
+      return if can?(:color_pdf, presenter)
+      raise CanCan::AccessDenied.new(nil, params[:action].to_sym)
+    end
+
+    def authorize_gray_pdf
+      return if can?(:pdf, presenter)
       raise CanCan::AccessDenied.new(nil, params[:action].to_sym)
     end
 

--- a/app/forms/curation_concerns/curation_concerns_form.rb
+++ b/app/forms/curation_concerns/curation_concerns_form.rb
@@ -1,6 +1,6 @@
 module CurationConcerns
   class CurationConcernsForm < CurationConcerns::Forms::WorkForm
-    self.terms += [:holding_location, :rights_statement, :rights_note, :source_metadata_identifier, :portion_note, :description, :state, :workflow_note, :collection_ids, :ocr_language, :nav_date]
+    self.terms += [:holding_location, :rights_statement, :rights_note, :source_metadata_identifier, :portion_note, :description, :state, :workflow_note, :collection_ids, :ocr_language, :nav_date, :pdf_type]
     delegate :collection_ids, to: :model
 
     def notable_rights_statement?
@@ -10,14 +10,33 @@ module CurationConcerns
     def self.multiple?(field)
       if field.to_sym == :description
         false
+      elsif field.to_sym == :pdf_type
+        false
       else
         super
       end
     end
 
+    # @param [ActiveSupport::Parameters]
+    # @return [Hash] a hash suitable for populating Collection attributes.
+    def self.model_attributes(_)
+      attrs = super
+      # cast pdf_type back to multivalued
+      attrs[:pdf_type] = Array(attrs[:pdf_type]) if attrs[:pdf_type]
+      attrs
+    end
+
     def initialize_field(key)
-      return if key.to_sym == :description
+      return if [:description, :pdf_type].include?(key.to_sym)
       super
+    end
+
+    def pdf_type
+      if self["pdf_type"].blank?
+        "gray"
+      else
+        self["pdf_type"]
+      end
     end
 
     def rights_statement

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,8 +4,8 @@ class Ability
 
   # Define any customized permissions here.
   def custom_permissions
-    alias_action :pdf, :show, :manifest, to: :read
-    alias_action :color_pdf, :edit, to: :modify
+    alias_action :show, :manifest, to: :read
+    alias_action :color_pdf, :pdf, :edit, to: :modify
     roles.each do |role|
       send "#{role}_permissions" if current_user.send "#{role}?"
     end
@@ -77,6 +77,12 @@ class Ability
   def curation_concern_read_permissions
     cannot [:read], curation_concerns do |curation_concern|
       !readable_concern?(curation_concern)
+    end
+    can :pdf, (curation_concerns + [ScannedResourceShowPresenter]) do |curation_concern|
+      ["color", "gray"].include?(Array(curation_concern.pdf_type).first)
+    end
+    can :color_pdf, (curation_concerns + [ScannedResourceShowPresenter]) do |curation_concern|
+      curation_concern.pdf_type == ["color"]
     end
   end
 

--- a/app/models/vocab/pul_terms.rb
+++ b/app/models/vocab/pul_terms.rb
@@ -4,4 +4,5 @@ class PULTerms < RDF::StrictVocabulary('http://library.princeton.edu/terms/')
   term :metadata_id, label: 'Metadata ID'.freeze, type: 'rdf:Property'.freeze
   term :source_metadata, label: 'Source Metadata'.freeze, type: 'rdf:Property'.freeze
   term :ocr_language, label: "OCR Language".freeze, type: 'rdf:Property'.freeze
+  term :pdf_type, label: "PDF Type".freeze, type: 'rdf:Property'.freeze
 end

--- a/app/schemas/plum_schema.rb
+++ b/app/schemas/plum_schema.rb
@@ -14,6 +14,7 @@ class PlumSchema < ActiveTriples::Schema
   property :holding_location, predicate: ::RDF::Vocab::Bibframe.heldBy, multiple: false
   property :ocr_language, predicate: ::PULTerms.ocr_language
   property :nav_date, predicate: ::RDF::URI("http://iiif.io/api/presentation/2#navDate"), multiple: false
+  property :pdf_type, predicate: ::PULTerms.pdf_type
 
   # Generated from Context
   property :coverage, predicate: RDF::DC11.coverage
@@ -289,7 +290,7 @@ class PlumSchema < ActiveTriples::Schema
   # Ignore things like admin data (workflow note), title, description, etc, as
   # those have custom display logic.
   def self.display_fields
-    ScannedResource.properties.values.map(&:term) - [:description, :state, :rights_statement, :holding_location, :title, :depositor, :source_metadata_identifier, :source_metadata, :date_modified, :date_uploaded, :workflow_note, :nav_date] - IIIFBookSchema.properties.map(&:name)
+    ScannedResource.properties.values.map(&:term) - [:description, :state, :rights_statement, :holding_location, :title, :depositor, :source_metadata_identifier, :source_metadata, :date_modified, :date_uploaded, :workflow_note, :nav_date, :pdf_type] - IIIFBookSchema.properties.map(&:name)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/services/manifest_builder/pdf_link_builder.rb
+++ b/app/services/manifest_builder/pdf_link_builder.rb
@@ -20,7 +20,11 @@ class ManifestBuilder
     private
 
       def path
-        helper.polymorphic_url([:pdf, record], pdf_quality: "gray", protocol: protocol)
+        if record.pdf_type == ["color"]
+          helper.polymorphic_url([:pdf, record], pdf_quality: "color", protocol: protocol)
+        else
+          helper.polymorphic_url([:pdf, record], pdf_quality: "gray", protocol: protocol)
+        end
       rescue
         nil
       end

--- a/app/views/curation_concerns/base/_form_supplementary_fields.html.erb
+++ b/app/views/curation_concerns/base/_form_supplementary_fields.html.erb
@@ -5,6 +5,11 @@
 <%= render "form_collections", f: f %>
 
 <div class="row with-headroom">
+  <legend>PDF Type</legend>
+  <%= f.input :pdf_type, collection: {"Color PDF" => "color", "Grayscale PDF" => "gray"}.to_a %>
+</div>
+
+<div class="row with-headroom">
   <div class="col-md-12">
     <%= render "form_permission", curation_concern: curation_concern, f: f %>
   </div>

--- a/spec/ability/roles_spec.rb
+++ b/spec/ability/roles_spec.rb
@@ -247,12 +247,20 @@ describe Ability do
   describe 'as an anonymous user' do
     let(:creating_user) { FactoryGirl.create(:image_editor) }
     let(:current_user) { nil }
+    let(:color_enabled_resource) {
+      FactoryGirl.build(:open_scanned_resource, user: creating_user, state: 'complete', pdf_type: ['color'])
+    }
+    let(:no_pdf_scanned_resource) {
+      FactoryGirl.build(:open_scanned_resource, user: creating_user, state: 'complete', pdf_type: [])
+    }
     it { should be_able_to(:read, open_scanned_resource) }
     it { should be_able_to(:manifest, open_scanned_resource) }
     it { should be_able_to(:pdf, open_scanned_resource) }
     it { should be_able_to(:read, complete_scanned_resource) }
     it { should be_able_to(:read, flagged_scanned_resource) }
+    it { should be_able_to(:color_pdf, color_enabled_resource) }
 
+    it { should_not be_able_to(:pdf, no_pdf_scanned_resource) }
     it { should_not be_able_to(:flag, open_scanned_resource) }
     it { should_not be_able_to(:read, campus_only_scanned_resource) }
     it { should_not be_able_to(:read, private_scanned_resource) }

--- a/spec/factories/scanned_resources.rb
+++ b/spec/factories/scanned_resources.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
     description "900 years of time and space, and I’ve never been slapped by someone’s mother."
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     state "complete"
+    pdf_type ["gray"]
 
     transient do
       user { FactoryGirl.create(:user) }

--- a/spec/features/edit_scanned_resource_spec.rb
+++ b/spec/features/edit_scanned_resource_spec.rb
@@ -28,6 +28,7 @@ RSpec.feature "ScannedResourcesController", type: :feature do
       fill_in 'scanned_resource_portion_note', with: 'new portion note'
       fill_in 'scanned_resource_description', with: 'new description'
       fill_in 'scanned_resource_nav_date', with: '2016-04-01T01:01:01Z'
+      select 'Color PDF', from: 'scanned_resource_pdf_type'
       choose 'Final Review'
 
       click_button 'Update Scanned resource'

--- a/spec/features/new_scanned_resource_spec.rb
+++ b/spec/features/new_scanned_resource_spec.rb
@@ -14,6 +14,7 @@ RSpec.feature "ScannedResourcesController", type: :feature do
 
       fill_in 'scanned_resource_title', with: 'Test Title'
       expect(page).to have_select 'scanned_resource_rights_statement', selected: 'No Known Copyright'
+      expect(page).to have_select 'scanned_resource_pdf_type', selected: 'Grayscale PDF'
       click_button 'Create Scanned resource'
 
       expect(page).to have_selector("h1", "Test Title")

--- a/spec/models/scanned_resource_spec.rb
+++ b/spec/models/scanned_resource_spec.rb
@@ -252,4 +252,15 @@ describe ScannedResource do
       expect(solr_doc['collection_slug_sim']).to eq(scanned_resource.in_collections.first.exhibit_id)
     end
   end
+
+  describe "#pdf_type" do
+    it "is empty by default" do
+      expect(described_class.new.pdf_type).to eq []
+    end
+    it "can be set" do
+      subject.pdf_type = ["color"]
+
+      expect(subject.pdf_type).to eq ["color"]
+    end
+  end
 end

--- a/spec/services/polymorphic_manifest_builder_spec.rb
+++ b/spec/services/polymorphic_manifest_builder_spec.rb
@@ -220,6 +220,12 @@ RSpec.describe PolymorphicManifestBuilder, vcr: { cassette_name: "iiif_manifest"
       it "has a pdf link" do
         expect(manifest_json['sequences'][0]["rendering"]["@id"]).to eql "http://plum.com/concern/scanned_resources/1/pdf/gray"
       end
+      context "when given a color PDF enabled resource" do
+        let(:record) { FactoryGirl.build(:scanned_resource, pdf_type: ['color']) }
+        it "has a color PDF link" do
+          expect(manifest_json['sequences'][0]["rendering"]["@id"]).to eql "http://plum.com/concern/scanned_resources/1/pdf/color"
+        end
+      end
       context "when given SSL" do
         subject { described_class.new(solr_document, ssl: true) }
         it "generates https links appropriately for pdfs" do


### PR DESCRIPTION
We should probably figure out the predicates/objects for this, but want to make sure this is the necessary functionality.

Effectively this adds a dropdown to the form to select grayscale or color. It defaults to grayscale. If you select the empty option, then there's no PDF available.

Closes #511.