### PR TITLE
Don't use original file's mime type.

### DIFF
--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -18,7 +18,7 @@ class FileSet < ActiveFedora::Base
   end
 
   def create_derivatives(filename)
-    case original_file.mime_type
+    case mime_type
     when 'image/tiff'
       Hydra::Derivatives::Jpeg2kImageDerivatives.create(
         filename,

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe FileSet do
       expect(thumbnail_path).not_to exist
     end
     it "creates a JP2" do
+      subject.mime_type = "image/tiff"
       allow_any_instance_of(described_class).to receive(:warn) # suppress virus check warnings
       file = File.open(Rails.root.join("spec", "fixtures", "files", "color.tif"))
       Hydra::Works::UploadFileToFileSet.call(subject, file)
@@ -46,6 +47,7 @@ RSpec.describe FileSet do
       expect(path).to exist
     end
     it "creates full text and indexes it" do
+      subject.mime_type = "image/tiff"
       allow_any_instance_of(described_class).to receive(:warn) # suppress virus check warnings
       allow(Hydra::Derivatives::Jpeg2kImageDerivatives).to receive(:create).and_return(true)
       file = File.open(Rails.root.join("spec", "fixtures", "files", "page18.tif"))


### PR DESCRIPTION
Derivatives are sometimes run before the original file hits Fedora.