### PR TITLE
Upgrading Solr to 6.0.1

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,5 +1,5 @@
 # Place any default configuration for solr_wrapper here
-version: 6.0.0
+version: 6.0.1
 port: 8983
 instance_dir: tmp/solr-development
 collection:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -687,7 +687,7 @@ GEM
       httparty (>= 0.11.0)
       oauth2 (>= 0.9.2)
     slop (3.6.0)
-    solr_wrapper (0.12.0)
+    solr_wrapper (0.12.1)
       ruby-progressbar
       rubyzip
     solrizer (3.4.0)

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -1,5 +1,5 @@
 #config/solr_wrapper_test.yml
-version: 6.0.0
+version: 6.0.1
 port: 8985
 instance_dir: tmp/solr-test
 collection:


### PR DESCRIPTION
* Fixes CircleCI failures that happen because Solr 6.0.0 is no longer available on mirrors.