### PR TITLE
Indexing logical_order as text to avoid string field size limit

### DIFF
--- a/app/models/concerns/structural_metadata.rb
+++ b/app/models/concerns/structural_metadata.rb
@@ -7,7 +7,7 @@ module StructuralMetadata
 
   def to_solr(solr_doc = {})
     super.tap do |doc|
-      doc[ActiveFedora.index_field_mapper.solr_name("logical_order", :symbol)] = [logical_order.order.to_json]
+      doc[ActiveFedora.index_field_mapper.solr_name("logical_order", :stored_searchable)] = [logical_order.order.to_json]
       doc[ActiveFedora.index_field_mapper.solr_name("logical_order_headings", :stored_searchable)] = logical_order.object.each_section.map(&:label)
     end
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -52,7 +52,7 @@ class SolrDocument
   def logical_order
     @logical_order ||=
       begin
-        JSON.parse(self[Solrizer.solr_name("logical_order", :symbol)].first)
+        JSON.parse(self[Solrizer.solr_name("logical_order", :stored_searchable)].first)
       rescue
         {}
       end

--- a/spec/support/shared_examples/structure.rb
+++ b/spec/support/shared_examples/structure.rb
@@ -68,7 +68,7 @@ RSpec.shared_examples "structural metadata" do
     it "marshals logical order into solr" do
       subject.logical_order.order = params
       subject.save
-      expect(subject.to_solr["logical_order_ssim"]).to eq [subject.logical_order.order.to_json]
+      expect(subject.to_solr["logical_order_tesim"]).to eq [subject.logical_order.order.to_json]
     end
     it "indexes the headings into the solr record" do
       subject.logical_order.order = params2


### PR DESCRIPTION
Fixes #672 