### PR TITLE
Adding metadata, improving pdf cover page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,6 +107,7 @@ gem 'bunny'
 gem 'string_rtl'
 gem 'sinatra'
 gem 'redis-namespace'
+gem 'arabic-letter-connector'
 source 'https://rails-assets.org' do
   gem 'rails-assets-babel-polyfill'
   gem 'rails-assets-bootstrap-select', '1.9.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,7 @@ GEM
     addressable (2.4.0)
     afm (0.2.2)
     amq-protocol (2.0.1)
+    arabic-letter-connector (0.1.1)
     arel (6.0.3)
     ast (2.2.0)
     astrolabe (1.3.1)
@@ -768,6 +769,7 @@ PLATFORMS
 DEPENDENCIES
   aasm
   active-fedora!
+  arabic-letter-connector
   browse-everything!
   bunny
   capistrano (= 3.4.0)

--- a/app/models/vocab/pul_terms.rb
+++ b/app/models/vocab/pul_terms.rb
@@ -5,4 +5,5 @@ class PULTerms < RDF::StrictVocabulary('http://library.princeton.edu/terms/')
   term :source_metadata, label: 'Source Metadata'.freeze, type: 'rdf:Property'.freeze
   term :ocr_language, label: "OCR Language".freeze, type: 'rdf:Property'.freeze
   term :pdf_type, label: "PDF Type".freeze, type: 'rdf:Property'.freeze
+  term :call_number, label: "Call Number".freeze, type: 'rdf:Property'.freeze
 end

--- a/app/schemas/plum_schema.rb
+++ b/app/schemas/plum_schema.rb
@@ -21,6 +21,8 @@ class PlumSchema < ActiveTriples::Schema
   property :format, predicate: RDF::DC11.format
   property :source, predicate: RDF::DC11.source
   property :extent, predicate: RDF::DC.extent
+  property :edition, predicate: RDF::URI("http://id.loc.gov/ontologies/bibframe/editionStatement")
+  property :call_number, predicate: PULTerms.call_number
   property :abridger, predicate: RDF::Vocab::MARCRelators.abr
   property :actor, predicate: RDF::Vocab::MARCRelators.act
   property :adapter, predicate: RDF::Vocab::MARCRelators.adp

--- a/app/values/scanned_resource_pdf/cover_page_generator.rb
+++ b/app/values/scanned_resource_pdf/cover_page_generator.rb
@@ -10,12 +10,21 @@ class ScannedResourcePDF
     def header(prawn_document, header, size: 16)
       Array(header).each do |text|
         prawn_document.move_down 10
-        prawn_document.text text, size: size, styles: [:bold]
+        prawn_document.text connect(text).join(" "), size: size, styles: [:bold]
       end
       prawn_document.stroke do
         prawn_document.horizontal_rule
       end
       prawn_document.move_down 10
+    end
+
+    def text(prawn_document, text)
+      Array(text).each do |value|
+        connect(value).each do |chunk|
+          prawn_document.text chunk
+        end
+      end
+      prawn_document.move_down 5
     end
 
     def apply(prawn_document)
@@ -36,7 +45,10 @@ class ScannedResourcePDF
         prawn_document.move_down(20)
         header(prawn_document, scanned_resource.title, size: 24)
         solr_document.rights_statement.each do |statement|
-          prawn_document.text rights_statement_text(statement), align: :justify
+          text(prawn_document, rights_statement_label(statement))
+          rights_statement_text(statement).split(/\n/).each do |line|
+            text(prawn_document, line)
+          end
         end
         prawn_document.move_down 20
 
@@ -45,9 +57,16 @@ class ScannedResourcePDF
         prawn_document.move_down 20
 
         header(prawn_document, "Citation Information")
+        text(prawn_document, solr_document.creator)
+        text(prawn_document, solr_document.title)
+        text(prawn_document, solr_document.edition)
+        text(prawn_document, solr_document.extent)
+        text(prawn_document, solr_document.description)
+        text(prawn_document, solr_document.call_number)
+        # collection name (from EAD) ? not in jsonld
 
         header(prawn_document, "Contact Information")
-        text = HoldingLocationRenderer.new(solr_document.holding_location).value_html.gsub("<a", "<u><a").gsub("</a>", "</a></u>")
+        text = HoldingLocationRenderer.new(solr_document.holding_location).value_html.gsub("<a", "<u><a").gsub("</a>", "</a></u>").gsub(/\s+/, " ")
         prawn_document.text text, inline_format: true
         prawn_document.move_down 20
 
@@ -63,8 +82,28 @@ class ScannedResourcePDF
         @helper ||= ManifestBuilder::ManifestHelper.new
       end
 
+      def rights_statement_label(statement)
+        RightsService.label(statement)
+      end
+
       def rights_statement_text(statement)
         RightsStatementService.definition(statement).gsub(/<br\/>/, "\n")
+      end
+
+      def connect(text)
+        dir_split(text).map { |s| s.dir == 'rtl' && lang_is_arabic? ? s.connect_arabic_letters.reverse : s }
+      end
+
+      def lang_is_arabic?
+        solr_document.language && solr_document.language.first && solr_document.language.first == 'ara'
+      end
+
+      def dir_split(s)
+        chunks = []
+        s.split(/\s/).each do |word|
+          (chunks.last && chunks.last.dir == word.dir) ? chunks << "#{chunks.pop} #{word}" : chunks << word
+        end
+        chunks
       end
   end
 end


### PR DESCRIPTION
Fixes #415 

* Adds metadata
* Improves handling of Arabic and other LTR text
* Splits mixed LTR/RTL strings to display each part correctly

Sample PDF cover page:

[arabic-cover.pdf](https://github.com/pulibrary/plum/files/337049/arabic-cover.pdf)
