### PR TITLE
Fix AF::Noid in Production

### DIFF
--- a/app/models/minter_state.rb
+++ b/app/models/minter_state.rb
@@ -1,0 +1,29 @@
+class MinterState < ActiveRecord::Base
+  validates :namespace, presence: true, uniqueness: true
+  validates :template, presence: true
+  validates :template, format: { with: Object.const_get('Noid::Template::VALID_PATTERN'), message: 'value fails regex' }
+
+  # @return [Hash] options for Noid::Minter.new
+  # * template [String] setting the identifier pattern
+  # * seq [Integer] reflecting minter position in sequence
+  # * counters [Array{Hash}] "buckets" each with :current and :max values
+  # * rand [Object] random number generator object
+  def noid_options
+    Rails.logger.debug("
+    app/model/minter_state.rb is a placeholder for active_fedora-noid-2.0.0.beta1/app/models/minter_state.rb
+    See: https://github.com/projecthydra-labs/active_fedora-noid/issues/29
+    Once active_fedora-noid-2.0.0 is out of beta, and CurationConcerns no longer requires it,
+    remove this file.
+    (This isn't actually used by plum at all, it's just here to stop an initialization error in production)
+    See #292
+    ")
+    return nil unless template
+    opts = {
+      template: template,
+      seq: seq
+    }
+    opts[:counters] = JSON.parse(counters, symbolize_names: true) if counters
+    opts[:rand]     = Marshal.load(random) if random
+    opts
+  end
+end

--- a/db/migrate/20160610010003_create_minter_states.rb
+++ b/db/migrate/20160610010003_create_minter_states.rb
@@ -1,0 +1,14 @@
+class CreateMinterStates < ActiveRecord::Migration
+  def change
+    create_table :minter_states do |t|
+      t.string :namespace, null: false, default: 'default'
+      t.string :template, null: false
+      t.text :counters
+      t.bigint :seq, default: 0
+      t.binary :random
+      t.timestamps null: false
+    end
+    # Use both model and DB-level constraints for consistency while scaling horizontally
+    add_index :minter_states, :namespace, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160311185340) do
+ActiveRecord::Schema.define(version: 20160610010003) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -37,6 +37,18 @@ ActiveRecord::Schema.define(version: 20160311185340) do
   end
 
   add_index "checksum_audit_logs", ["file_set_id", "file_id"], name: "by_generic_file_id_and_file_id"
+
+  create_table "minter_states", force: :cascade do |t|
+    t.string   "namespace",            default: "default", null: false
+    t.string   "template",                                 null: false
+    t.text     "counters"
+    t.integer  "seq",        limit: 8, default: 0
+    t.binary   "random"
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
+  end
+
+  add_index "minter_states", ["namespace"], name: "index_minter_states_on_namespace", unique: true
 
   create_table "pending_uploads", force: :cascade do |t|
     t.string   "curation_concern_id"


### PR DESCRIPTION
This is a dirty temporary fix to allow production deploys to ship with
AF::Noid 2.0. Copied from UM's repository.