### PR TITLE
Adds startCanvas UI & Manifest Generation

### DIFF
--- a/app/assets/javascripts/file_manager/plum.es6
+++ b/app/assets/javascripts/file_manager/plum.es6
@@ -1,11 +1,12 @@
 import RadioTracker from "file_manager/radio_tracker"
 import SelectTracker from "file_manager/select_tracker"
-import {FileManagerMember} from "curation_concerns/file_manager/member"
+import {InputTracker, FileManagerMember} from "curation_concerns/file_manager/member"
 export default class PlumFileManager {
   constructor() {
     this.initialize_radio_buttons()
     this.sortable_placeholder()
     this.manage_iiif_fields()
+    this.starting_page()
   }
 
   initialize_radio_buttons() {
@@ -29,5 +30,19 @@ export default class PlumFileManager {
     new RadioTracker($("#resource-form > div:eq(1)"))
     // OCR Language
     new SelectTracker($("#resource-form select:eq(0)"))
+  }
+
+  get resource_manager() {
+    return $("#resource-form").parent().data("file_manager_member")
+  }
+
+  starting_page() {
+    // Track thumbnail ID hidden field
+    new InputTracker($("*[data-member-link=start_canvas]"), this.resource_manager)
+    $("#sortable *[name=start_canvas]").change(function() {
+      let val = $("#sortable *[name=start_canvas]:checked").val()
+      $("*[data-member-link=start_canvas]").val(val)
+      $("*[data-member-link=start_canvas]").change()
+    })
   }
 }

--- a/app/forms/curation_concerns/curation_concerns_form.rb
+++ b/app/forms/curation_concerns/curation_concerns_form.rb
@@ -1,6 +1,6 @@
 module CurationConcerns
   class CurationConcernsForm < CurationConcerns::Forms::WorkForm
-    self.terms += [:holding_location, :rights_statement, :rights_note, :source_metadata_identifier, :portion_note, :description, :state, :workflow_note, :collection_ids, :ocr_language, :nav_date, :pdf_type]
+    self.terms += [:holding_location, :rights_statement, :rights_note, :source_metadata_identifier, :portion_note, :description, :state, :workflow_note, :collection_ids, :ocr_language, :nav_date, :pdf_type, :start_canvas]
     delegate :collection_ids, to: :model
 
     def notable_rights_statement?

--- a/app/presenters/curation_concerns_show_presenter.rb
+++ b/app/presenters/curation_concerns_show_presenter.rb
@@ -41,6 +41,10 @@ class CurationConcernsShowPresenter < CurationConcerns::WorkShowPresenter
     Array.wrap(title).first
   end
 
+  def start_canvas
+    Array.wrap(solr_document.start_canvas).first
+  end
+
   private
 
     def logical_order_factory

--- a/app/schemas/plum_schema.rb
+++ b/app/schemas/plum_schema.rb
@@ -15,6 +15,7 @@ class PlumSchema < ActiveTriples::Schema
   property :ocr_language, predicate: ::PULTerms.ocr_language
   property :nav_date, predicate: ::RDF::URI("http://iiif.io/api/presentation/2#navDate"), multiple: false
   property :pdf_type, predicate: ::PULTerms.pdf_type
+  property :start_canvas, predicate: ::RDF::Vocab::IIIF.hasStartCanvas, multiple: false
 
   # Generated from Context
   property :coverage, predicate: RDF::Vocab::DC11.coverage

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -64,7 +64,7 @@ class ManifestBuilder
     end
 
     def sequence_builder
-      SequenceBuilder.new(root_path, canvas_builders)
+      SequenceBuilder.new(root_path, canvas_builders, start_canvas_builder)
     end
 
     def see_also_builder
@@ -101,5 +101,9 @@ class ManifestBuilder
 
     def logical_order
       @logical_order ||= LogicalOrder.new(record.logical_order)
+    end
+
+    def start_canvas_builder
+      StartCanvasBuilder.new(record, canvas_builders)
     end
 end

--- a/app/services/manifest_builder/sequence_builder.rb
+++ b/app/services/manifest_builder/sequence_builder.rb
@@ -1,9 +1,10 @@
 class ManifestBuilder
   class SequenceBuilder
-    attr_reader :parent_path, :canvas_builder
-    def initialize(parent_path, canvas_builder)
+    attr_reader :parent_path, :canvas_builder, :start_canvas_builder
+    def initialize(parent_path, canvas_builder, start_canvas_builder = nil)
       @parent_path = parent_path
       @canvas_builder = canvas_builder
+      @start_canvas_builder = start_canvas_builder
     end
 
     def apply(manifest)
@@ -23,6 +24,7 @@ class ManifestBuilder
             sequence = IIIF::Presentation::Sequence.new
             sequence["@id"] ||= parent_path.to_s + "/sequence/normal"
             canvas_builder.apply(sequence)
+            start_canvas_builder.apply(sequence) if start_canvas_builder
             sequence
           end
       end

--- a/app/services/manifest_builder/start_canvas_builder.rb
+++ b/app/services/manifest_builder/start_canvas_builder.rb
@@ -1,0 +1,32 @@
+class ManifestBuilder
+  class StartCanvasBuilder
+    attr_reader :record, :canvas_builders
+    def initialize(record, canvas_builders)
+      @record = record
+      @canvas_builders = canvas_builders
+    end
+
+    def apply(manifest)
+      manifest.tap do |m|
+        m["startCanvas"] = start_canvas_path if start_canvas_path
+      end
+    end
+
+    private
+
+      def start_canvas
+        record.try(:start_canvas)
+      end
+
+      def start_canvas_path
+        id_to_canvas[start_canvas]
+      end
+
+      def id_to_canvas
+        @id_to_canvas ||=
+          Hash[
+            canvas_builders.record.map(&:id).zip(canvas_builders.path)
+          ]
+      end
+  end
+end

--- a/app/views/curation_concerns/base/_file_manager_member_resource_options.html.erb
+++ b/app/views/curation_concerns/base/_file_manager_member_resource_options.html.erb
@@ -1,0 +1,12 @@
+      <div class="form-group radio_buttons member_resource_options">
+        <span class="radio">
+          <%= radio_button_tag "thumbnail_id", node.id, @presenter.thumbnail_id == node.id, id: "thumbnail_id_#{node.id}", class: "radio_buttons" %>
+          <%= label_tag "thumbnail_id_#{node.id}", "Thumbnail" %>
+        </span>
+      </div>
+      <div class="form-group radio_buttons member_resource_options">
+        <span class="radio">
+          <%= radio_button_tag "start_canvas", node.id, @presenter.start_canvas == node.id, id: "start_canvas_#{node.id}", class: "radio_buttons" %>
+          <%= label_tag "start_canvas_#{node.id}", "Starting Page" %>
+        </span>
+      </div>

--- a/app/views/curation_concerns/base/_file_manager_resource_form.html.erb
+++ b/app/views/curation_concerns/base/_file_manager_resource_form.html.erb
@@ -32,5 +32,6 @@
       <%= f.input :ocr_language, collection: Tesseract.languages.map(&:reverse).sort, input_html: { name: "#{f.object.model_name.singular}[ocr_language][]", multiple: true, class: 'resource-radio-button' } %>
     </div>
     <%= f.input :thumbnail_id, as: :hidden, input_html: { data: {member_link: 'thumbnail_id'}} %>
+    <%= f.input :start_canvas, as: :hidden, input_html: { data: {member_link: 'start_canvas'}} %>
   <% end %>
 </div>

--- a/spec/controllers/curation_concerns/scanned_resources_controller_spec.rb
+++ b/spec/controllers/curation_concerns/scanned_resources_controller_spec.rb
@@ -176,6 +176,10 @@ describe CurationConcerns::ScannedResourcesController do
         expect(reloaded.title).to eq ['Dummy Title']
         expect(reloaded.description).to eq 'a description'
       end
+      it "can update the start_canvas" do
+        post :update, id: scanned_resource, scanned_resource: { start_canvas: "1" }
+        expect(reloaded.start_canvas).to eq "1"
+      end
       context "when in a collection" do
         let(:scanned_resource) { FactoryGirl.create(:scanned_resource_in_collection, user: user) }
         it "doesn't remove the item from collections" do

--- a/spec/services/polymorphic_manifest_builder_spec.rb
+++ b/spec/services/polymorphic_manifest_builder_spec.rb
@@ -137,6 +137,7 @@ RSpec.describe PolymorphicManifestBuilder, vcr: { cassette_name: "iiif_manifest"
         record.ordered_members << file_set2
         record.ordered_member_proxies.insert_target_at(0, file_set)
         record.thumbnail = file_set2
+        record.start_canvas = file_set2.id
         record.logical_order.order = {
           "label": "TOP!",
           "nodes": [
@@ -182,6 +183,9 @@ RSpec.describe PolymorphicManifestBuilder, vcr: { cassette_name: "iiif_manifest"
             "profile" => "http://iiif.io/api/image/2/level2.json"
           }
         )
+      end
+      it "applies the startCanvas option for the start_canvas" do
+        expect(manifest_json["sequences"].first["startCanvas"]).to eq manifest_json["sequences"].first["canvases"].last["@id"]
       end
       it "has a viewing hint on the sequence" do
         expect(manifest_json["sequences"].first["viewingHint"]).to eq "individuals"

--- a/spec/views/curation_concerns/base/file_manager.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/file_manager.html.erb_spec.rb
@@ -138,6 +138,14 @@ RSpec.describe "curation_concerns/base/file_manager.html.erb" do
     expect(rendered).to have_text "English"
   end
 
+  it "has a hidden field for start_canvas" do
+    expect(rendered).to have_selector("input[type=hidden][name='scanned_resource[start_canvas]']", visible: false)
+  end
+
+  it "has a shared radio button for start_canvas" do
+    expect(rendered).to have_selector("input[name='start_canvas']", count: members.length)
+  end
+
   context "when it's a MVW" do
     let(:parent) { FactoryGirl.build(:multi_volume_work) }
     it "has a correct input to edit the viewing hint" do


### PR DESCRIPTION
Allows you to select the canvas which the viewer should start on. Looks like the following:

<img width="809" alt="screen shot 2016-08-22 at 11 03 21 am" src="https://cloud.githubusercontent.com/assets/2806645/17865600/131bb6c2-6858-11e6-9027-be5d7be3b70f.png">

Closes #239