### PR TITLE
Remove the attach a file button from scanned resources show page

### DIFF
--- a/app/views/curation_concerns/scanned_resources/_show_actions.html.erb
+++ b/app/views/curation_concerns/scanned_resources/_show_actions.html.erb
@@ -4,7 +4,6 @@
       <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]), class: 'btn btn-default' %>
       <%= link_to t('file_manager.link_text'), ContextualPath.new(@presenter, @parent_presenter).file_manager, class: 'btn btn-default' %>
       <%= link_to "Edit Structure", ContextualPath.new(@presenter, @parent_presenter).structure, class: 'btn btn-default' %>
-      <%= link_to "Attach a File", main_app.new_curation_concerns_file_set_path(@presenter), class: 'btn btn-default' %>
       <% if can?(:color_pdf, ScannedResource) %>
         <div class="btn-group">
           <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/spec/features/edit_scanned_resource_spec.rb
+++ b/spec/features/edit_scanned_resource_spec.rb
@@ -45,18 +45,17 @@ RSpec.feature "ScannedResourcesController", type: :feature do
       expect(page).to have_text("Error retrieving metadata")
     end
 
-    scenario "User can add a new file" do
+    scenario "User can follow link to bulk edit scanned resource and add a new file" do
       allow(CharacterizeJob).to receive(:perform_later).once
       allow_any_instance_of(FileSet).to receive(:warn) # suppress virus warning messages
 
       visit polymorphic_path [scanned_resource]
-      click_link 'Attach a File'
-      expect(page).not_to have_text("A PDF is preferred")
+      click_link I18n.t('file_manager.link_text')
+      expect(page).to have_text(I18n.t('file_manager.link_text'))
 
       within("form.new_file_set") do
-        fill_in("Title", with: 'image.png')
-        attach_file("Upload a file", File.join(Rails.root, 'spec/fixtures/files/image.png'))
-        click_on("Attach to Scanned Resource")
+        attach_file("file_set[files][]", File.join(Rails.root, 'spec/fixtures/files/image.png'))
+        click_on("Start upload")
       end
 
       visit polymorphic_path [parent_presenter.member_presenters.first]
@@ -64,12 +63,6 @@ RSpec.feature "ScannedResourcesController", type: :feature do
 
       visit edit_polymorphic_path [scanned_resource]
       expect(page).not_to have_text('Representative Media')
-    end
-
-    scenario "User can follow link to bulk edit scanned resource" do
-      visit polymorphic_path [scanned_resource]
-      click_link I18n.t('file_manager.link_text')
-      expect(page).to have_text(I18n.t('file_manager.link_text'))
     end
   end
 

--- a/spec/views/curation_concerns/scanned_resources/_show_actions.html.erb_spec.rb
+++ b/spec/views/curation_concerns/scanned_resources/_show_actions.html.erb_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe "curation_concerns/scanned_resources/_show_actions.html.erb" do
   it "renders an Edit Structure link" do
     expect(rendered).to have_link "Edit Structure", href: structure_curation_concerns_scanned_resource_path(id: resource.id)
   end
+  it "does not render an Attach a File link" do
+    expect(rendered).not_to have_selector 'a.btn', text: 'Attach a File'
+  end
   context "when there's a parent presenter" do
     let(:parent_presenter) { presenter }
     it "renders a link to the contextual file manager" do


### PR DESCRIPTION
Removes the `Attach a File` button from the scanned resources show page. Closes #669.