### PR TITLE
Fixes universal viewer fullscreen layout issue

### DIFF
--- a/app/assets/javascripts/plum_boot.es6
+++ b/app/assets/javascripts/plum_boot.es6
@@ -3,6 +3,7 @@ import BulkLabeler from "bulk_labeler/bulk_label"
 import ModalViewer from "modal_viewer"
 import PlumFileManager from "file_manager/plum"
 import StructureManager from "structure_manager"
+import UniversalViewer from "universal_viewer"
 export default class Initializer {
   constructor() {
     this.initialize_bootstrap_select()
@@ -12,6 +13,7 @@ export default class Initializer {
     this.initialize_timepicker()
     this.initialize_plum_file_manager()
     this.structure_manager = new StructureManager
+    this.universal_viewer = new UniversalViewer
   }
 
   initialize_bootstrap_select() {

--- a/app/assets/javascripts/universal_viewer.es6
+++ b/app/assets/javascripts/universal_viewer.es6
@@ -1,0 +1,35 @@
+export default class UniversalViewer {
+  constructor() {
+    this.addFullscreenEventListeners()
+  }
+
+  addFullscreenEventListeners() {
+    if (document.addEventListener) {
+      document.addEventListener("webkitfullscreenchange", () => this.exitHandler(this), false)
+      document.addEventListener("mozfullscreenchange", () => this.exitHandler(this), false)
+      document.addEventListener("fullscreenchange", () => this.exitHandler(this), false)
+      document.addEventListener("MSFullscreenChange", () => this.exitHandler(this), false)
+    }
+  }
+
+  /** 
+  * Asynchronously removes styling from the universal viewer iframe after a timeout.
+  * This is a workaround for issues related to exiting fullscreen mode by pressing the
+  * escape key.
+  */
+  exitHandler() {
+    let fullscreen = document.webkitIsFullScreen || document.mozFullScreen || document.msFullscreenElement
+
+    if (fullscreen !== true) {
+      this.sleep(200).then(() => {
+        let frame = document.getElementsByTagName("iframe")[0]
+        frame.style.top = null
+        frame.style.left = null
+      })
+    }
+  }
+
+  sleep(time) {
+    return new Promise((resolve) => setTimeout(resolve, time))
+  }
+}


### PR DESCRIPTION
Workaround for an issue with exiting fullscreen mode in the universal viewer. This adds an event handler on fullscreen events. When leaving fullscreen mode, the handler triggers a 200ms async timeout and then removes incorrect styling from the uv iframe element. Closes #690.