### PR TITLE
Correcting state vocab URI

### DIFF
--- a/app/models/vocab/f3_access.rb
+++ b/app/models/vocab/f3_access.rb
@@ -1,4 +1,4 @@
 require 'rdf'
-class F3Access < RDF::StrictVocabulary('http://fedora.info/definitions/1/0/access/')
+class F3Access < RDF::StrictVocabulary('http://fedora.info/definitions/1/0/access/ObjState#')
   term :objState, label: 'Object State'.freeze, type: 'rdf:Property'.freeze
 end


### PR DESCRIPTION
See comment in https://github.com/projecthydra/curation_concerns/pull/928.

Comment was deleted, but this file was added with the new URI (https://github.com/projecthydra/curation_concerns/pull/928/files#diff-cd8301655bae865486bf87bf43dfc9edR3) and there was a comment saying that it was changed and the original file was copied from Plum so we should update too.