### PR TITLE
Adjusting fonts and sizing of RTL text

### DIFF
--- a/app/assets/stylesheets/base/typography.scss
+++ b/app/assets/stylesheets/base/typography.scss
@@ -57,3 +57,8 @@ body .form-control {
     font-size: 1.3em;
   }
 }
+
+[dir='rtl'] {
+  font-family: verdana, arial;
+  font-size: 150%;
+}

--- a/app/renderers/rtl_linked_attribute_renderer.rb
+++ b/app/renderers/rtl_linked_attribute_renderer.rb
@@ -1,0 +1,18 @@
+class RtlLinkedAttributeRenderer < AttributeRenderer
+  def li_value(value)
+    link_to(ERB::Util.h(value), search_path(value))
+  end
+
+  def li_markup(value, attributes)
+    "<li#{html_attributes(attributes)} dir=#{value.dir}>#{attribute_value_to_html(value.to_s)}</li>"
+  end
+
+  def search_path(value)
+    Rails.application.routes.url_helpers.search_catalog_path(
+      search_field: search_field, q: ERB::Util.h(value))
+  end
+
+  def search_field
+    options.fetch(:search_field, field)
+  end
+end

--- a/app/views/curation_concerns/base/_attributes.html.erb
+++ b/app/views/curation_concerns/base/_attributes.html.erb
@@ -4,7 +4,7 @@
     <tr><th>Attribute Name</th><th>Values</th></tr>
   </thead>
   <tbody>
-  <%= @presenter.attribute_to_html(:creator, render_as: 'linked' ) %>
+  <%= @presenter.attribute_to_html(:creator, render_as: 'rtl_linked' ) %>
   <% (PlumSchema.display_fields - [:creator]).each do |display_field| %>
     <%= @presenter.attribute_to_html(display_field) %>
   <% end %>


### PR DESCRIPTION
Fixes #632 

Here is what the titles look like before:
![plum-before](https://cloud.githubusercontent.com/assets/856924/17974281/7c5cb930-6ab3-11e6-8aa5-f7188a9cbbcf.png)

And here is what they look like after this change:
![plum-after](https://cloud.githubusercontent.com/assets/856924/17974282/7c601ddc-6ab3-11e6-9ea9-58794d376204.png)
