### PR TITLE
Link MultiVolumeWork children before ingesting files

### DIFF
--- a/app/jobs/ingest_mets_job.rb
+++ b/app/jobs/ingest_mets_job.rb
@@ -108,12 +108,12 @@ class IngestMETSJob < ActiveJob::Base
         r.save!
         logger.info "Created ScannedResource: #{r.id}"
 
+        parent.ordered_members << r
+        parent.save!
+
         ingest_files(parent: parent, resource: r, files: @mets.files_for_volume(volume_id))
         r.logical_order.order = map_fileids(@mets.structure_for_volume(volume_id))
         r.save!
-
-        parent.ordered_members << r
-        parent.save!
       end
     end
 


### PR DESCRIPTION
Linking before ingesting files means that any failures wouldn't prevent the child resources from being linked to the parent MultiVolumeWork.

Fixes #766 