### PR TITLE
Do ordering only after all the FileSets are loaded

### DIFF
--- a/app/actors/batch_file_set_actor.rb
+++ b/app/actors/batch_file_set_actor.rb
@@ -1,0 +1,25 @@
+class BatchFileSetActor < ::CurationConcerns::Actors::FileSetActor
+  def attach_file_to_work(work, file_set, file_set_params)
+    copy_visibility(work, file_set) unless assign_visibility?(file_set_params)
+    work.members << file_set
+    work.save
+
+    CurationConcerns.config.callback.run(:after_create_fileset, file_set, user)
+  end
+
+  def attach_related_object(resource)
+    file_set.apply_depositor_metadata(user)
+    resource.related_objects << file_set
+    resource.save
+  end
+
+  def attach_content(file, relation = 'original_file')
+    Hydra::Works::AddFileToFileSet.call(file_set, file, relation.to_sym, versioning: false)
+  end
+
+  private
+
+    def file_actor_class
+      ::FileActor
+    end
+end

--- a/app/actors/file_set_actor.rb
+++ b/app/actors/file_set_actor.rb
@@ -5,12 +5,6 @@ class FileSetActor < ::CurationConcerns::Actors::FileSetActor
     end
   end
 
-  def attach_related_object(resource)
-    file_set.apply_depositor_metadata(user)
-    resource.related_objects << file_set
-    resource.save
-  end
-
   def attach_content(file, relation = 'original_file')
     Hydra::Works::AddFileToFileSet.call(file_set, file, relation.to_sym, versioning: false)
   end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,7 +3,7 @@
 staging:
   :concurrency: 2
 production:
-  :concurrency: 5
+  :concurrency: 1
 :queues:
   - high
   - ingest

--- a/spec/jobs/ingest_mets_job_spec.rb
+++ b/spec/jobs/ingest_mets_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe IngestMETSJob do
     let(:order_object) { double('order_object') }
 
     before do
-      allow(FileSetActor).to receive(:new).and_return(actor1, actor2)
+      allow(BatchFileSetActor).to receive(:new).and_return(actor1, actor2)
       allow(FileSet).to receive(:new).and_return(fileset)
       allow(MultiVolumeWork).to receive(:new).and_return(work)
       allow(ScannedResource).to receive(:new).and_return(resource1, resource2)


### PR DESCRIPTION
Use a custom FileSetActor to avoid locking the parent work, adding to ordered_members, etc.