### PR TITLE
Fix ordering in batch ingest

### DIFF
--- a/app/jobs/ingest_mets_job.rb
+++ b/app/jobs/ingest_mets_job.rb
@@ -103,17 +103,18 @@ class IngestMETSJob < ActiveJob::Base
 
       mets_to_repo_map[f[:id]] = file_set.id
 
-      return unless f[:path] == @mets.thumbnail_path
-      resource.thumbnail_id = file_set.id
-      resource.save!
-      parent.thumbnail_id = file_set.id if parent
+      if f[:path] == @mets.thumbnail_path
+        resource.thumbnail_id = file_set.id
+        resource.save!
+        parent.thumbnail_id = file_set.id if parent
+      end
 
       return file_set
     rescue StandardError => e
       raise e if count > 4
       count += 1
       logger.info "Failed ingesting #{f[:path]} #{count} times, retrying. Error: #{e.message}"
-      ingest_file(parent: parent, resource: resource, f: f, count: count)
+      return ingest_file(parent: parent, resource: resource, f: f, count: count)
     end
 
     def ingest_volumes(parent)

--- a/spec/jobs/ingest_mets_job_spec.rb
+++ b/spec/jobs/ingest_mets_job_spec.rb
@@ -90,6 +90,7 @@ RSpec.describe IngestMETSJob do
       allow(actor2).to receive(:create_content)
       described_class.perform_now(mets_file_rtl, user)
       expect(resource1.viewing_direction).to eq('right-to-left')
+      expect(resource1.ordered_members.to_a.length).to eq 189
     end
 
     it "ingests a multi-volume mets file", vcr: { cassette_name: 'bibdata-4609321' } do
@@ -103,6 +104,8 @@ RSpec.describe IngestMETSJob do
       allow(logical_order).to receive(:order).and_return(nil)
       allow(logical_order).to receive(:object).and_return(order_object)
       allow(order_object).to receive(:each_section).and_return([])
+      expect(resource1).to receive(:ordered_members=)
+      expect(resource2).to receive(:ordered_members=)
       described_class.perform_now(mets_file_multi, user)
       expect(work.ordered_member_ids).to eq(['resource1', 'resource2'])
     end


### PR DESCRIPTION
Changes guard condition to make sure a FileSet is always returned from `IngestMETSJob#ingest_file`