### PR TITLE
remove thumbnail select in work edit view

### DIFF
--- a/app/views/curation_concerns/base/_form_supplementary_fields.html.erb
+++ b/app/views/curation_concerns/base/_form_supplementary_fields.html.erb
@@ -1,7 +1,5 @@
 <%= render "form_files_and_links", curation_concern: curation_concern, f: f %>
 
-<%= render "form_media", f: f %>
-
 <%= render "form_member_of_collections", f: f %>
 
 <%= render "form_in_works", f: f %>

--- a/spec/features/edit_scanned_resource_spec.rb
+++ b/spec/features/edit_scanned_resource_spec.rb
@@ -63,6 +63,7 @@ RSpec.feature "ScannedResourcesController", type: :feature do
 
       visit edit_polymorphic_path [scanned_resource]
       expect(page).not_to have_text('Representative Media')
+      expect(page).not_to have_text('Thumbnail')
     end
   end
 


### PR DESCRIPTION
Removes [form_media](https://github.com/projecthydra/curation_concerns/blob/master/app/views/curation_concerns/base/_form_media.html.erb) partial from work edit view. This partial included the representative media and thumbnail form partials. Closes #767 