### PR TITLE
Speedup all collections view.

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -31,10 +31,10 @@ class CollectionsController < ApplicationController
   private
 
     def manifest_builder
-      PolymorphicManifestBuilder.new(presenter, ssl: request.ssl?)
+      @manifest_builder ||= PolymorphicManifestBuilder.new(presenter, ssl: request.ssl?)
     end
 
     def all_manifests_builder
-      AllCollectionsManifestBuilder.new(nil, ability: current_ability, ssl: request.ssl?)
+      @all_manifests_builder ||= AllCollectionsManifestBuilder.new(nil, ability: current_ability, ssl: request.ssl?)
     end
 end

--- a/app/presenters/all_collections_presenter.rb
+++ b/app/presenters/all_collections_presenter.rb
@@ -40,7 +40,7 @@ class AllCollectionsPresenter < CollectionShowPresenter
       @current_ability ||= nil
     end
 
-    def ordered_ids
-      ActiveFedora::SolrService.query("has_model_ssim:Collection", rows: 10_000, fl: "id").map { |x| x["id"] }
+    def ordered_docs
+      @ordered_docs ||= ActiveFedora::SolrService.query("has_model_ssim:Collection", rows: 10_000).map { |x| SolrDocument.new(x) }
     end
 end

--- a/app/services/all_collections_manifest_builder.rb
+++ b/app/services/all_collections_manifest_builder.rb
@@ -20,7 +20,7 @@ class AllCollectionsManifestBuilder < ManifestBuilder
     end
 
     def child_manifest_factory
-      ChildCollectionManifest
+      SparseMemberCollectionManifest
     end
 
     def record_property_builder

--- a/app/services/only_property_manifest_builder.rb
+++ b/app/services/only_property_manifest_builder.rb
@@ -1,0 +1,16 @@
+class OnlyPropertyManifestBuilder < ManifestBuilder
+  def builders
+    @builders ||=
+      CompositeBuilder.new(
+        record_property_builder
+      )
+  end
+
+  def manifest_builder_class
+    if record.viewing_hint == "multi-part"
+      IIIF::Presentation::Collection.new
+    else
+      IIIF::Presentation::Manifest.new
+    end
+  end
+end

--- a/app/services/sparse_member_collection_manifest.rb
+++ b/app/services/sparse_member_collection_manifest.rb
@@ -1,0 +1,10 @@
+class SparseMemberCollectionManifest < ManifestBuilder
+  def apply(manifest)
+    manifest['collections'] ||= []
+    manifest['collections'] += [self.manifest]
+  end
+
+  def child_manifest_factory
+    OnlyPropertyManifestBuilder
+  end
+end

--- a/spec/services/all_collections_manifest_builder_spec.rb
+++ b/spec/services/all_collections_manifest_builder_spec.rb
@@ -13,9 +13,12 @@ RSpec.describe AllCollectionsManifestBuilder do
     it "embeds manifests" do
       c = FactoryGirl.create(:collection)
       s = FactoryGirl.create(:scanned_resource_with_multi_volume_work)
+      s2 = FactoryGirl.create(:scanned_resource)
       mvw = s.in_works.first
       mvw.member_of_collections = [c]
       mvw.save!
+      s2.member_of_collections = [c]
+      s2.save!
 
       expect(manifest_json["collections"].length).to eq 1
       expect(manifest_json["collections"].first["manifests"]).not_to be_blank


### PR DESCRIPTION
Only display manifest URIs instead of canvases, and do it all with one
solr query.