### PR TITLE
Hide children you don't have access to.

### DIFF
--- a/app/services/all_collections_manifest_builder.rb
+++ b/app/services/all_collections_manifest_builder.rb
@@ -27,6 +27,10 @@ class AllCollectionsManifestBuilder < ManifestBuilder
       ManifestBuilder::CollectionRecordPropertyBuilder.new(record, root_path)
     end
 
+    def manifest_builder_class
+      IIIF::Presentation::Collection.new
+    end
+
     def sequence_builder
       nil
     end

--- a/app/services/manifest_builder/manifest_builder_factory.rb
+++ b/app/services/manifest_builder/manifest_builder_factory.rb
@@ -17,7 +17,7 @@ class ManifestBuilder
 
     def manifest_presenters
       record.member_presenters.select do |x|
-        x.model_name.name != "FileSet"
+        x.model_name.name != "FileSet" && (!x.current_ability || x.current_ability.can?(:read, x.solr_document))
       end
     end
   end

--- a/spec/presenters/collection_show_presenter_spec.rb
+++ b/spec/presenters/collection_show_presenter_spec.rb
@@ -50,6 +50,26 @@ RSpec.describe CollectionShowPresenter do
     expect(json_manifest['viewingDirection']).to eq nil
   end
 
+  context "when the user doesn't have permission to a child resource" do
+    subject { described_class.new(solr_doc, ability) }
+    let(:ability) { Ability.new(user) }
+    let(:user) { FactoryGirl.create(:user) }
+    let(:scanned_resource) do
+      s = FactoryGirl.build(:private_scanned_resource)
+      s.member_of_collections = [collection]
+      allow(s).to receive(:id).and_return("resource")
+      solr.add(s.to_solr)
+      s
+    end
+    it "doesn't show up in the collection's manifests" do
+      manifest = nil
+      expect { manifest = ManifestBuilder.new(subject).to_json }.not_to raise_error
+      json_manifest = JSON.parse(manifest)
+
+      expect(json_manifest["manifests"]).to be_nil
+    end
+  end
+
   describe "#label" do
     it "is an empty array" do
       expect(subject.label).to eq []


### PR DESCRIPTION
With this, IIIF collections won't show manifests or collections you
don't have access to.