### PR TITLE
Use the first FileSet as thumbnail if not explicitly set

### DIFF
--- a/app/jobs/ingest_mets_job.rb
+++ b/app/jobs/ingest_mets_job.rb
@@ -135,6 +135,7 @@ class IngestMETSJob < ActiveJob::Base
 
         ingest_files(parent: parent, resource: r, files: @mets.files_for_volume(volume_id))
         r.logical_order.order = map_fileids(@mets.structure_for_volume(volume_id))
+        r.thumbnail_id = r.file_sets.first.id unless r.thumbnail_id
         r.save!
       end
     end

--- a/spec/jobs/ingest_mets_job_spec.rb
+++ b/spec/jobs/ingest_mets_job_spec.rb
@@ -106,6 +106,10 @@ RSpec.describe IngestMETSJob do
       allow(order_object).to receive(:each_section).and_return([])
       expect(resource1).to receive(:ordered_members=)
       expect(resource2).to receive(:ordered_members=)
+      allow(resource1).to receive(:file_sets).and_return([fileset])
+      allow(resource2).to receive(:file_sets).and_return([fileset])
+      expect(resource1).to receive(:thumbnail_id=)
+      expect(resource2).to receive(:thumbnail_id=)
       described_class.perform_now(mets_file_multi, user)
       expect(work.ordered_member_ids).to eq(['resource1', 'resource2'])
     end


### PR DESCRIPTION
Fixes #789 