### PR TITLE
Add simple-tiles dependencies to circleci

### DIFF
--- a/bin/ci_simple_tiles_install.sh
+++ b/bin/ci_simple_tiles_install.sh
@@ -1,0 +1,5 @@
+curl -L https://github.com/propublica/simple-tiles/archive/v0.6.0.tar.gz | tar -xz
+cd simple-tiles-0.6.0
+./configure && make
+make install
+cd ..

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,8 @@ dependencies:
     - kakadu
   pre:
     - npm install -g eslint
-    - sudo apt-get install libmagickwand-dev imagemagick redis-server tesseract-ocr tesseract-ocr-ita tesseract-ocr-eng sqlite3 libsqlite3-dev
+    - sudo apt-get install libmagickwand-dev imagemagick redis-server tesseract-ocr tesseract-ocr-ita tesseract-ocr-eng sqlite3 libsqlite3-dev libgdal-dev gdal-bin libcairo2-dev libpango1.0-dev
+    - sudo sh bin/ci_simple_tiles_install.sh
   post:
     - sudo sh bin/ci_kakadu_install.sh
     - bundle exec rake rubocop


### PR DESCRIPTION
Adds simple-tiles dependencies to circleci config. Build and install the binary. Closes #838