### PR TITLE
Generate thumbnail paths for geo works

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -22,8 +22,8 @@ class CatalogController < ApplicationController
     config.index.title_field = solr_name('title', :stored_searchable)
     config.index.display_type_field = solr_name('has_model', :symbol)
 
-    # config.index.thumbnail_field = 'thumbnail_path_ss'
-    config.index.thumbnail_method = :iiif_thumbnail_path
+    config.index.thumbnail_field = 'thumbnail_path_ss'
+    config.index.thumbnail_method = :plum_thumbnail_path
     # config.index.partials.delete(:thumbnail) # we render this inside _index_default.html.erb
     config.index.partials += [:action_menu]
 

--- a/app/helpers/geo_concerns_helper.rb
+++ b/app/helpers/geo_concerns_helper.rb
@@ -1,0 +1,6 @@
+module GeoConcernsHelper
+  def geo_concerns_thumbnail_path(document, image_options = {})
+    url = thumbnail_url(document)
+    image_tag url, image_options if url.present?
+  end
+end

--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -1,0 +1,29 @@
+module ThumbnailHelper
+  # Generates a thumbnail path for the various work and fileset types.
+  # @param document [SolrDocument, ShowPresenter] an object's solr document or show presenter
+  # @param image_options [Hash]
+  # @return [String] thumbnail tag
+  def plum_thumbnail_path(document, image_options = {})
+    value = send(plum_thumbnail_method(document), document, image_options)
+    link_to_document document, value if value
+  end
+
+  # Gets the correct thumbnail path generation method
+  # for work or fileset type.
+  # @param document [SolrDocument, ShowPresenter] an object's solr document or show presenter
+  # @return [Symbol]
+  def plum_thumbnail_method(document)
+    document = document.solr_document if document.respond_to?(:solr_document)
+    class_name = document.to_model.class_name
+
+    if document['geo_mime_type_tesim']
+      # geo fileset
+      :geo_concerns_thumbnail_path
+    elsif ["ImageWork", "RasterWork", "VectorWork"].include?(class_name)
+      # geo work
+      :geo_concerns_thumbnail_path
+    else
+      :iiif_thumbnail_path
+    end
+  end
+end

--- a/spec/factories/vector_works.rb
+++ b/spec/factories/vector_works.rb
@@ -1,0 +1,14 @@
+FactoryGirl.define do
+  factory :vector_work do
+    title ["Test title"]
+    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    end
+  end
+end

--- a/spec/helpers/thumbnail_helper_spec.rb
+++ b/spec/helpers/thumbnail_helper_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe ThumbnailHelper do
+  subject { helper }
+
+  before do
+    allow(subject).to receive(:thumbnail_url).and_return('thumbnail.jpg')
+  end
+
+  context 'when document is a geo FileSet' do
+    let(:file_set) { FactoryGirl.create(:file_set, geo_mime_type: 'application/vnd.geo+json') }
+    let(:document) do
+      FileSetPresenter.new(
+        SolrDocument.new(
+          file_set.to_solr
+        ), nil
+      )
+    end
+
+    it 'returns a path to the thumbnail image' do
+      expect(subject).to receive(:link_to_document).with(document, /<img src=\"\/images\/thumbnail.jpg/)
+      subject.plum_thumbnail_path(document)
+    end
+  end
+
+  context 'when document is a VectorWork' do
+    let(:vector_work) { FactoryGirl.create(:vector_work) }
+    let(:document) do
+      GeoConcerns::VectorWorkShowPresenter.new(
+        SolrDocument.new(
+          vector_work.to_solr
+        ), nil
+      )
+    end
+
+    it 'returns a path to the thumbnail image' do
+      expect(subject).to receive(:link_to_document).with(document, /<img src=\"\/images\/thumbnail.jpg/)
+      subject.plum_thumbnail_path(document)
+    end
+  end
+
+  context 'when document is a ScannedResource' do
+    let(:scanned_resource) { FactoryGirl.create(:scanned_resource) }
+    let(:document) do
+      ScannedResourceShowPresenter.new(
+        SolrDocument.new(
+          scanned_resource.to_solr
+        ), nil
+      )
+    end
+
+    before do
+      allow(document).to receive(:thumbnail_id).and_return('abcdefg')
+    end
+
+    it 'returns a path to the iiif thumbnail' do
+      expect(subject).to receive(:link_to_document).with(document, /ab%2Fcd%2Fef%2Fg-intermediate_file.jp2/)
+      subject.plum_thumbnail_path(document)
+    end
+  end
+end

--- a/spec/views/curation_concerns/base/structure.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/structure.html.erb_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "curation_concerns/base/structure" do
 
   def build_file_set(id:, to_s:)
     i = instance_double(FileSetPresenter, id: id, thumbnail_id: id, to_s: to_s, collection?: false)
+    allow(i).to receive(:solr_document).and_return(SolrDocument.new(FileSet.new(id: "test").to_solr))
     allow(IIIFPath).to receive(:new).with(id).and_return(double(thumbnail: nil))
     i
   end


### PR DESCRIPTION
Merges into geo_concerns branch.

Creates new thumbnail path helpers for different object types. Geo works and geo filesets use the `geo_concerns_thumbnail_path` helper method, while other work types and filesets still use the `iiif_thumbnail_path` helper method. Closes #840  