### PR TITLE
Skip removal of pending uploads for geo objects

### DIFF
--- a/app/jobs/ingest_file_job.rb
+++ b/app/jobs/ingest_file_job.rb
@@ -23,6 +23,7 @@ class IngestFileJob < ActiveJob::Base
     # Persist changes to the file_set
     file_set.save!
     file_set.in_works.each do |work|
+      next unless work.respond_to? :pending_uploads
       work.pending_uploads.where(file_name: local_file.original_name).destroy_all
     end
 


### PR DESCRIPTION
Merges into geo_concerns branch.

Skip removal of pending uploads for geo objects in ingest job. Geo works don't respond to pending uploads yet. Closes #839 