### PR TITLE
Don't ingest files into Fedora

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -23,4 +23,8 @@ class DownloadsController < ApplicationController
       file_path = PairtreeDerivativePath.derivative_path_for_reference(asset, file_reference)
       File.exist?(file_path) ? file_path : nil
     end
+
+    def default_file
+      File.exist?(asset.local_file) ? asset.local_file : super
+    end
 end

--- a/app/jobs/ingest_file_job.rb
+++ b/app/jobs/ingest_file_job.rb
@@ -6,19 +6,16 @@ class IngestFileJob < ActiveJob::Base
   # @param [String,NilClass] mime_type
   # @param [User] user
   # @param [String] relation ('original_file')
-  def perform(file_set, filepath, user, opts = {})
+  def perform(file_set, filepath, _user, opts = {})
     relation = opts.fetch(:relation, :original_file).to_sym
 
     # Wrap in an IO decorator to attach passed-in options
-    local_file = Hydra::Derivatives::IoDecorator.new(File.open(filepath, "rb"))
-    local_file.mime_type = opts.fetch(:mime_type, nil)
+    local_file = Hydra::Derivatives::IoDecorator.new File.new(File::NULL)
+    local_file.mime_type = "message/external-body; access-type=URL; url=\"#{local_file_url(file_set)}\""
     local_file.original_name = opts.fetch(:filename, File.basename(filepath))
 
     # Tell AddFileToFileSet service to skip versioning because versions will be minted by VersionCommitter (called by save_characterize_and_record_committer) when necessary
-    Hydra::Works::AddFileToFileSet.call(file_set,
-                                        local_file,
-                                        relation,
-                                        versioning: false)
+    Hydra::Works::AddFileToFileSet.call(file_set, local_file, relation, versioning: false)
 
     # Persist changes to the file_set
     file_set.save!
@@ -27,12 +24,14 @@ class IngestFileJob < ActiveJob::Base
     end
 
     repository_file = file_set.send(relation)
+    CharacterizeJob.perform_later(file_set, repository_file.id, filepath)
+  end
 
-    # Do post file ingest actions
-    CurationConcerns::VersioningService.create(repository_file, user)
+  def local_file_url(file_set)
+    download_url(file_set)
+  end
 
-    # TODO: this is a problem, the file may not be available at this path on another machine.
-    # It may be local, or it may be in s3
-    CharacterizeJob.perform_later(file_set, repository_file.id)
+  def download_url(file_set)
+    Plum.config[:file_url_module].constantize.download_url(file_set)
   end
 end

--- a/app/jobs/run_ocr_job.rb
+++ b/app/jobs/run_ocr_job.rb
@@ -1,8 +1,9 @@
 class RunOCRJob < ActiveJob::Base
   queue_as :lowest
 
-  def perform(file_set_id)
+  def perform(file_set_id, filename = nil)
     file_set = FileSet.find(file_set_id)
-    OCRRunner.new(file_set).from_datastream
+    OCRRunner.new(file_set).from_file((filename || file_set.local_file))
+    file_set.save
   end
 end

--- a/app/schemas/new_mime_type_schema.rb
+++ b/app/schemas/new_mime_type_schema.rb
@@ -1,0 +1,3 @@
+class NewMimeTypeSchema < ActiveTriples::Schema
+  property :mime_type_storage, predicate: RDF::URI.new("http://test.com/mimeType")
+end

--- a/app/services/external_file_url_generator.rb
+++ b/app/services/external_file_url_generator.rb
@@ -1,0 +1,6 @@
+class ExternalFileUrlGenerator
+  def self.download_url(file_set)
+    pair = file_set.id.scan(/..?/).first(4) # TODO: add .push(id) when CC is updated
+    "#{Plum.config[:external_file_url]}/#{pair.join('/')}/#{file_set.label || file_set.id}"
+  end
+end

--- a/app/services/local_file_url_generator.rb
+++ b/app/services/local_file_url_generator.rb
@@ -1,0 +1,5 @@
+class LocalFileUrlGenerator
+  def self.download_url(file_set)
+    Rails.application.routes.url_helpers.download_url file_set
+  end
+end

--- a/app/services/ocr_runner.rb
+++ b/app/services/ocr_runner.rb
@@ -9,25 +9,7 @@ class OCRRunner
                            params)
   end
 
-  def from_datastream
-    Hydra::Derivatives::TempfileService.create(resource.original_file) do |f|
-      ocr_output = from_file(f.path)
-      attach_ocr(ocr_filename(ocr_output))
-    end
-    resource.save
-  end
-
   private
-
-    def attach_ocr(filename)
-      basename = File.basename(filename) if filename
-      iodec = Hydra::Derivatives::IoDecorator.new(File.open(filename, 'rb'), 'text/html', basename)
-      Hydra::Works::AddFileToFileSet.call(resource, iodec, :extracted_text)
-    end
-
-    def ocr_filename(ocr_output)
-      ocr_output.first[:url].sub(/^file:/, '')
-    end
 
     def creator_factory
       OCRCreator

--- a/config/config.yml
+++ b/config/config.yml
@@ -2,6 +2,7 @@ defaults: &defaults
   locations_url: https://bibdata.princeton.edu/locations/digital_locations.json
   notifier_email_address: plum@princeton.edu
   iiif_url: <%= ENV["PLUM_IIIF_URL"] || "http://192.168.99.100:5004" %>
+  file_url_module: LocalFileUrlGenerator
   jp2_recipes:
     default_color: >
       -rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171 
@@ -45,12 +46,16 @@ test:
 
 production:
   <<: *defaults
+  file_url_module: ExternalFileUrlGenerator
+  external_file_url: "http://plum.princeton.edu:9090"
   events:
     server: <%= ENV['PLUM_RABBIT_SERVER'] || 'amqp://localhost:5672' %>
     exchange: "plum_events"
 
 staging:
   <<: *defaults
+  file_url_module: ExternalFileUrlGenerator
+  external_file_url: "http://localhost:9000"
   events:
     server: <%= ENV['PLUM_RABBIT_SERVER'] || 'amqp://localhost:5672' %>
     exchange: "plum_events"

--- a/config/initializers/redirect_mime_type.rb
+++ b/config/initializers/redirect_mime_type.rb
@@ -1,0 +1,5 @@
+ActiveFedora::WithMetadata::DefaultMetadataClassFactory.file_metadata_schemas +=
+  [
+    NewMimeTypeSchema
+  ]
+Hydra::Works::Characterization.mapper = Hydra::Works::Characterization.mapper.merge(file_mime_type: :mime_type_storage)

--- a/spec/controllers/curation_concerns/multi_volume_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/multi_volume_works_controller_spec.rb
@@ -50,7 +50,9 @@ describe CurationConcerns::MultiVolumeWorksController do
     it "appends a new file set" do
       reloaded = resource.reload
       expect(reloaded.file_sets.length).to eq 1
-      expect(reloaded.file_sets.first.files.first.mime_type).to eq "image/tiff"
+      first_file = reloaded.file_sets.first.files.first
+      expect(first_file.original_name).to eq "color.tif"
+      expect(first_file.mime_type).to eq "message/external-body;access-type=URL;url=\"http://plum.com/downloads/#{reloaded.file_sets.first.id}\""
       path = Rails.application.class.routes.url_helpers.file_manager_curation_concerns_multi_volume_work_path(resource)
       expect(response).to redirect_to path
       expect(reloaded.pending_uploads.length).to eq 0

--- a/spec/controllers/curation_concerns/scanned_resources_controller_spec.rb
+++ b/spec/controllers/curation_concerns/scanned_resources_controller_spec.rb
@@ -222,7 +222,7 @@ describe CurationConcerns::ScannedResourcesController do
       it "updates OCR on file sets" do
         ocr_runner = instance_double(OCRRunner)
         allow(OCRRunner).to receive(:new).and_return(ocr_runner)
-        allow(ocr_runner).to receive(:from_datastream)
+        allow(ocr_runner).to receive(:from_file)
 
         post :update, id: scanned_resource, scanned_resource: scanned_resource_attributes
 
@@ -427,7 +427,7 @@ describe CurationConcerns::ScannedResourcesController do
       post :browse_everything_files, id: resource.id, selected_files: params["selected_files"]
       reloaded = resource.reload
       expect(reloaded.file_sets.length).to eq 1
-      expect(reloaded.file_sets.first.files.first.mime_type).to eq "image/tiff"
+      expect(reloaded.file_sets.first.files.first.original_name).to eq "color.tif"
       path = Rails.application.class.routes.url_helpers.file_manager_curation_concerns_scanned_resource_path(resource)
       expect(response).to redirect_to path
       expect(reloaded.pending_uploads.length).to eq 0

--- a/spec/decorators/updates_ocr_spec.rb
+++ b/spec/decorators/updates_ocr_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe UpdatesOCR do
   let(:file_set) { FactoryGirl.create(:file_set, content: file) }
   let(:file) { File.open(Rails.root.join("spec", "fixtures", "files", "page18.tif")) }
   before do
+    allow(File).to receive(:open).and_call_original
+    allow(File).to receive(:open).with(file_set.local_file).and_return(file)
     subject.ordered_members << file_set
     subject.save
   end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -43,27 +43,24 @@ RSpec.describe FileSet do
       allow_any_instance_of(described_class).to receive(:warn) # suppress virus check warnings
       file = File.open(Rails.root.join("spec", "fixtures", "files", "color.tif"))
       Hydra::Works::UploadFileToFileSet.call(subject, file)
+      allow(subject.characterization_proxy).to receive(:mime_type_storage).and_return(["image/tiff"])
 
       subject.create_derivatives(file.path)
 
       expect(path).to exist
     end
-    it "creates full text, attaches it to the object, and indexes it" do
+    it "creates full text and indexes it" do
       allow_any_instance_of(described_class).to receive(:warn) # suppress virus check warnings
       allow(Hydra::Derivatives::Jpeg2kImageDerivatives).to receive(:create).and_return(true)
       file = File.open(Rails.root.join("spec", "fixtures", "files", "page18.tif"))
       Hydra::Works::UploadFileToFileSet.call(subject, file)
       allow_any_instance_of(HOCRDocument).to receive(:text).and_return("yo")
+      allow(subject.characterization_proxy).to receive(:mime_type_storage).and_return(["image/tiff"])
 
       subject.create_derivatives(file.path)
 
       expect(ocr_path).to exist
       expect(subject.to_solr["full_text_tesim"]).to eq "yo"
-
-      # verify that ocr has been added to the FileSet
-      subject.reload
-      expect(subject.files.size).to eq(2)
-      expect(subject.files.to_a.find { |x| x.mime_type != "image/tiff" }.content).to include "<div class='ocr_page'"
     end
     after do
       FileUtils.rm_rf(path.parent) if path.exist?


### PR DESCRIPTION
* Skip ingesting files into Fedora
* DownloadController serves files from disk instead of Fedora
* Characterization/Derivatives/OCR use files from disk