### PR TITLE
Trigger manifest event in fileset actor only if parent is not a geo work

### DIFF
--- a/app/actors/file_set_actor.rb
+++ b/app/actors/file_set_actor.rb
@@ -1,7 +1,7 @@
 class FileSetActor < ::CurationConcerns::Actors::FileSetActor
   def attach_file_to_work(*args)
     super.tap do |_result|
-      messenger.record_updated(args.first)
+      messenger.record_updated(args.first) unless args.first.is_a? GeoConcerns::BasicGeoMetadata
     end
   end
 

--- a/spec/actors/file_set_actor_spec.rb
+++ b/spec/actors/file_set_actor_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe FileSetActor do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:scanned_resource) { FactoryGirl.build(:scanned_resource, id: 'id') }
+  let(:vector_work) { FactoryGirl.build(:vector_work, id: 'id') }
+  let(:file_set) { FactoryGirl.build(:file_set) }
+  let(:messenger) { double }
+  let(:actor) do
+    described_class.new(file_set, user)
+  end
+  subject { actor }
+
+  before do
+    allow(ManifestEventGenerator).to receive(:new).and_return(messenger)
+  end
+
+  describe '#attach_file_to_work' do
+    context 'when the parent work is a ScannedResource' do
+      it 'fires a record_updated manifest event' do
+        expect(messenger).to receive(:record_updated)
+        subject.attach_file_to_work(scanned_resource, file_set, {})
+      end
+    end
+
+    context 'when the parent work is a VectorWork' do
+      it 'does not fire a record_updated manifest event' do
+        expect(messenger).to_not receive(:record_updated)
+        subject.attach_file_to_work(vector_work, file_set, {})
+      end
+    end
+  end
+end

--- a/spec/factories/vector_works.rb
+++ b/spec/factories/vector_works.rb
@@ -1,0 +1,14 @@
+FactoryGirl.define do
+  factory :vector_work do
+    title ["Test title"]
+    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    end
+  end
+end


### PR DESCRIPTION
Merges into geo_concerns branch.

Adds logic to not fire a manifest record updated event when the parent is a geo work. Geo works aren't synced with pomegranate (yet). Closes #851 

