### PR TITLE
Change bbox label color to black

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -37,6 +37,7 @@
 
 @import 'base/typography';
 
+@import 'components/bounding_box';
 @import 'components/breadcrumb';
 @import 'components/datepicker';
 @import 'components/fileupload';

--- a/app/assets/stylesheets/components/bounding_box.scss
+++ b/app/assets/stylesheets/components/bounding_box.scss
@@ -1,0 +1,5 @@
+.bbox-inputs {
+  span.input-group-addon {
+    color: $black;
+  }
+}


### PR DESCRIPTION
Makes the bounding box labels easier to read. Closes #875 

![screenshot 2016-12-13 11 22 12](https://cloud.githubusercontent.com/assets/784196/21151034/aea95abe-c126-11e6-819c-67a4514cddc2.png)


