### PR TITLE
Override geoserver delivery service base path method

### DIFF
--- a/app/services/geo_concerns/delivery_service.rb
+++ b/app/services/geo_concerns/delivery_service.rb
@@ -1,0 +1,11 @@
+module GeoConcerns
+  class DeliveryService
+    attr_reader :geoserver
+
+    def initialize(file_set, file_path)
+      @geoserver = ::Geoserver.new(file_set, file_path)
+    end
+
+    delegate :publish, to: :geoserver
+  end
+end

--- a/app/services/geoserver.rb
+++ b/app/services/geoserver.rb
@@ -1,0 +1,14 @@
+require 'active_support/core_ext/hash/indifferent_access'
+require 'rgeoserver'
+require 'yaml'
+require 'erb'
+
+class Geoserver < GeoConcerns::Delivery::Geoserver
+  attr_reader :config, :workspace_name, :file_set, :file_path
+
+  private
+
+    def base_path(path)
+      path.gsub(Plum.config[:geo_derivatives_path], '')
+    end
+end

--- a/spec/services/geo_concerns/delivery_service_spec.rb
+++ b/spec/services/geo_concerns/delivery_service_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe GeoConcerns::DeliveryService do
+  let(:path) { 'path-to-display-copy' }
+  let(:file_set) { instance_double("FileSet") }
+
+  describe '#initialize' do
+    it 'calls local geoserver service' do
+      expect(Geoserver).to receive(:new)
+      described_class.new(file_set, path)
+    end
+  end
+end

--- a/spec/services/geoserver_spec.rb
+++ b/spec/services/geoserver_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe Geoserver do
+  let(:file_set) { instance_double("FileSet") }
+  let(:visibility) { 'open' }
+  let(:geo_derivatives_path) { 'path/to/geo-derivatives' }
+  let(:plum_config) { { geo_derivatives_path: geo_derivatives_path } }
+  let(:relative_derivative_path) { '/d5/13/8j/d8/7v-display_vector/test.shp' }
+  let(:path) { "#{geo_derivatives_path}#{relative_derivative_path}" }
+
+  subject { described_class.new file_set, path }
+
+  before do
+    allow(file_set).to receive(:visibility).and_return(visibility)
+    allow(Plum).to receive(:config).and_return(plum_config)
+  end
+
+  describe '#base_path' do
+    it 'returns the correct base path to the derivative' do
+      expect(subject.send(:base_path, path)).to eq(relative_derivative_path)
+    end
+  end
+end


### PR DESCRIPTION
Overrides geoserver delivery service base path method. The method uses `derivatives` path rather than the `geo-derivatives` path which creates an issue in Plum.

Closes #886.