### PR TITLE
Limit number of subjects displayed on index page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -51,7 +51,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_index_field solr_name('description', :stored_searchable)
     config.add_index_field solr_name('tag', :stored_searchable)
-    config.add_index_field solr_name('subject', :stored_searchable)
+    config.add_index_field solr_name('subject', :stored_searchable), helper_method: :index_subject
     config.add_index_field solr_name('creator', :stored_searchable)
     config.add_index_field solr_name('contributor', :stored_searchable)
     config.add_index_field solr_name('publisher', :stored_searchable)

--- a/app/helpers/index_view_helper.rb
+++ b/app/helpers/index_view_helper.rb
@@ -1,0 +1,7 @@
+module IndexViewHelper
+  # Limit the number of subjects displayed on index page.
+  # Mainly because of geo works.
+  def index_subject(args)
+    args[:document].subject.take(7).join("<br/>")
+  end
+end

--- a/spec/helpers/index_view_helper_spec.rb
+++ b/spec/helpers/index_view_helper_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe IndexViewHelper do
+  subject { helper }
+  let(:document) { instance_double(SolrDocument, subject: subject_list) }
+  let(:args) { { document: document } }
+
+  describe '#index_subject' do
+    context 'with a long list of subject terms' do
+      let(:subject_list) { ['1', '2', '3', '4', '5', '6', '7', '8', '9'] }
+      it 'returns a list with a maximum of 7 items' do
+        expect(subject.index_subject(args)).to eq '1<br/>2<br/>3<br/>4<br/>5<br/>6<br/>7'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Limits the number of subjects displayed on index page items to seven. Needed because, at the moment, some geo works have messy metadata and very long lists of subject terms. Closes #905 