### PR TITLE
Use system dates for sorting

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -235,13 +235,13 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     # label is key, solr field is value
-    config.add_sort_field "score desc, #{uploaded_field} desc", label: "relevance \u25BC"
+    config.add_sort_field "score desc, system_modified_dtsi desc", label: "relevance \u25BC"
     config.add_sort_field "title_ssort asc", label: "title (A-Z)"
     config.add_sort_field "title_ssort desc", label: "title (Z-A)"
-    config.add_sort_field "#{uploaded_field} desc", label: "date uploaded \u25BC"
-    config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
-    config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
-    config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
+    config.add_sort_field "system_create_dtsi desc", label: "date created \u25BC"
+    config.add_sort_field "system_create_dtsi asc", label: "date created \u25B2"
+    config.add_sort_field "system_modified_dtsi desc", label: "date modified \u25BC"
+    config.add_sort_field "system_modified_dtsi asc", label: "date modified \u25B2"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.


### PR DESCRIPTION
The only dates reliably present in production are `system_create_dtsi` and `system_modified_dtsi`

Fixes #932 