### PR TITLE
Sipity workflow state for METS ingest

### DIFF
--- a/app/services/workflow/initialize_state.rb
+++ b/app/services/workflow/initialize_state.rb
@@ -1,0 +1,9 @@
+module Workflow
+  module InitializeState
+    def self.call(resource, workflow_name, state_name)
+      workflow = Sipity::Workflow.where(name: workflow_name).first
+      state = workflow.workflow_states.where(name: state_name).first
+      Sipity::Entity.create!(proxy_for_global_id: resource.to_global_id, workflow_state: state, workflow: workflow)
+    end
+  end
+end

--- a/spec/jobs/ingest_mets_job_spec.rb
+++ b/spec/jobs/ingest_mets_job_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe IngestMETSJob do
       allow_any_instance_of(METSDocument).to receive(:thumbnail_path).and_return(file_path)
       allow_any_instance_of(METSDocument).to receive(:source_file).and_return(mets_file)
       allow_any_instance_of(ScannedResource).to receive(:save!)
+      allow_any_instance_of(ScannedResource).to receive(:workflow_state).and_return('final_review')
+      allow(Workflow::InitializeState).to receive(:call)
     end
 
     it "ingests a mets file", vcr: { cassette_name: 'bibdata-4612596' } do
@@ -43,7 +45,6 @@ RSpec.describe IngestMETSJob do
       expect(resource1.title).to eq(["Ars minor [fragment]."])
       expect(resource1.thumbnail_id).to eq('file1')
       expect(resource1.viewing_direction).to eq('left-to-right')
-      expect(resource1.state).to eq('final_review')
       expect(resource1.visibility).to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
     end
     context "when an error happens during ingest", vcr: { cassette_name: 'bibdata-4612596' } do
@@ -64,7 +65,6 @@ RSpec.describe IngestMETSJob do
         expect(resource1.title).to eq(["Ars minor [fragment]."])
         expect(resource1.thumbnail_id).to eq('file1')
         expect(resource1.viewing_direction).to eq('left-to-right')
-        expect(resource1.state).to eq('final_review')
         expect(resource1.visibility).to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
       end
     end
@@ -139,6 +139,10 @@ RSpec.describe IngestMETSJob do
 
       allow(IngestFileJob).to receive(:perform_later).and_return(true)
       allow(CharacterizeJob).to receive(:perform_later).and_return(true)
+    end
+
+    before(:all) do
+      CurationConcerns::Workflow::WorkflowImporter.load_workflows
     end
 
     it "ingests a mets file", vcr: { cassette_name: 'bibdata-4612596' } do


### PR DESCRIPTION
Updating the METS ingest job to use Sipity workflow instead of the state property.