### PR TITLE
Adding Grocer and configuring to export when transitioning to Metadata Review state

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,6 +118,7 @@ group :staging, :development do
 end
 gem 'rbtrace', require: false
 gem 'pul_uv_rails', github: 'pulibrary/pul_uv_rails', branch: 'master'
+gem 'grocer', github: 'pulibrary/grocer', branch: 'spawn'
 source 'https://rails-assets.org' do
   gem 'rails-assets-babel-polyfill'
   gem 'rails-assets-bootstrap-select', '1.9.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,15 @@ GIT
       om (~> 3.1)
 
 GIT
+  remote: git://github.com/pulibrary/grocer.git
+  revision: 9824808403395529073eb4c720efb897b8f1eda8
+  branch: spawn
+  specs:
+    grocer (0.1.0)
+      active-fedora
+      kaminari
+
+GIT
   remote: git://github.com/pulibrary/pul_metadata_services.git
   revision: 584736f58b3dcf1136e9b1817954299d5e6ca82c
   branch: relax-activesupport-dependency
@@ -819,6 +828,7 @@ DEPENDENCIES
   factory_girl_rails
   fcrepo_wrapper (~> 0.6.0)
   geo_concerns (~> 0.3.4)
+  grocer!
   hydra-derivatives (= 3.1.3)
   hydra-pcdm!
   hydra-role-management (~> 0.2.0)

--- a/app/assets/javascripts/grocer.js
+++ b/app/assets/javascripts/grocer.js
@@ -1,0 +1,1 @@
+//= require grocer/application

--- a/app/assets/stylesheets/grocer.scss
+++ b/app/assets/stylesheets/grocer.scss
@@ -1,0 +1,1 @@
+@import 'grocer/grocer';

--- a/config/initializers/grocer.rb
+++ b/config/initializers/grocer.rb
@@ -1,0 +1,3 @@
+Grocer.configure do |conf|
+  conf.export_dir = ENV['PLUM_EXPORT_DIR'] || Rails.root.join('tmp', 'export')
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount Grocer::Engine => '/'
   mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
   mount BrowseEverything::Engine => '/browse'
 

--- a/config/workflows/books_workflow.json
+++ b/config/workflows/books_workflow.json
@@ -25,6 +25,7 @@
             }
           ],
           "transition_to": "metadata_review",
+          "methods": ["Grocer::ExportObject"],
           "notifications": [
             {
               "notification_type": "email",

--- a/db/migrate/20170127153850_create_grocer_exports.grocer.rb
+++ b/db/migrate/20170127153850_create_grocer_exports.grocer.rb
@@ -1,0 +1,16 @@
+# This migration comes from grocer (originally 20170119220038)
+class CreateGrocerExports < ActiveRecord::Migration[5.0]
+  def change
+    create_table :grocer_exports do |t|
+      t.string :pid
+      t.integer :job
+      t.string :status
+      t.datetime :last_error
+      t.datetime :last_success
+      t.string :logfile
+
+      t.timestamps
+    end
+    add_index :grocer_exports, :pid, unique: true
+  end
+end

--- a/db/migrate/20170127153851_add_ark_to_grocer_exports.grocer.rb
+++ b/db/migrate/20170127153851_add_ark_to_grocer_exports.grocer.rb
@@ -1,0 +1,6 @@
+# This migration comes from grocer (originally 20170124154627)
+class AddArkToGrocerExports < ActiveRecord::Migration[5.0]
+  def change
+    add_column :grocer_exports, :ark, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170103194043) do
+ActiveRecord::Schema.define(version: 20170127153851) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -54,6 +54,19 @@ ActiveRecord::Schema.define(version: 20170103194043) do
     t.index ["parent_id"], name: "index_curation_concerns_operations_on_parent_id"
     t.index ["rgt"], name: "index_curation_concerns_operations_on_rgt"
     t.index ["user_id"], name: "index_curation_concerns_operations_on_user_id"
+  end
+
+  create_table "grocer_exports", force: :cascade do |t|
+    t.string   "pid"
+    t.integer  "job"
+    t.string   "status"
+    t.datetime "last_error"
+    t.datetime "last_success"
+    t.string   "logfile"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.string   "ark"
+    t.index ["pid"], name: "index_grocer_exports_on_pid", unique: true
   end
 
   create_table "minter_states", force: :cascade do |t|


### PR DESCRIPTION
* Adds Grocer to CC 2.0 branch, configured to export objects when they enter the Metadata Review state
* Requires a build of the Fedora Import/Export client master branch