### PR TITLE
Fixes geoserver delivery in hyrax

### DIFF
--- a/app/jobs/delivery_job.rb
+++ b/app/jobs/delivery_job.rb
@@ -1,0 +1,36 @@
+require 'uri'
+
+##
+# Delivers derivatives to external services, like GeoServer
+##
+class DeliveryJob < ActiveJob::Base
+  queue_as Hyrax.config.ingest_queue_name
+
+  attr_reader :file_set
+
+  ##
+  # Precondition is that all derivatives are created and saved.
+  # @param [FileSet] file_set
+  # @param [String] content_url contains the display copy to deliver
+  def perform(message)
+    @file_set = ActiveFedora::Base.find(message['id'])
+    uri = URI.parse(content_url)
+    return if uri.path == ''
+    GeoWorks::DeliveryService.new(file_set, uri.path).publish
+  end
+
+  def content_url
+    case file_set.geo_mime_type
+    when *GeoWorks::RasterFormatService.select_options.map(&:last)
+      return derivatives_service.send(:derivative_url, 'display_raster')
+    when *GeoWorks::VectorFormatService.select_options.map(&:last)
+      return derivatives_service.send(:derivative_url, 'display_vector')
+    else
+      return ''
+    end
+  end
+
+  def derivatives_service
+    GeoDerivativesService.new(file_set)
+  end
+end

--- a/spec/jobs/delivery_job_spec.rb
+++ b/spec/jobs/delivery_job_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe DeliveryJob do
+  let(:id) { 'ab' }
+  let(:file_set) { instance_double(FileSet, id: id, geo_mime_type: file_format) }
+
+  before do
+    allow(subject).to receive(:file_set).and_return(file_set)
+  end
+
+  describe '#content_url' do
+    context 'with a vector file' do
+      let(:file_format) { 'application/zip; ogr-format="ESRI Shapefile"' }
+      it 'returns a path to the vector file' do
+        expect(subject.content_url).to include('ab-display_vector.zip')
+      end
+    end
+
+    context 'with a raster file' do
+      let(:file_format) { 'image/tiff; gdal-format=GTiff' }
+      it 'returns a path to the raster file' do
+        expect(subject.content_url).to include('ab-display_raster.tif')
+      end
+    end
+
+    context 'with a non-geospatial file' do
+      let(:file_format) { 'image/jpeg' }
+      it 'returns an empty path' do
+        expect(subject.content_url).to eq('')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes geoserver delivery in hyrax. `derivatives_service` needs to return `GeoDerivativesService` to get the proper derivative path.