### PR TITLE
Allow ImageWorks to pull metadata from bibdata

### DIFF
--- a/app/controllers/hyrax/geo_works_controller.rb
+++ b/app/controllers/hyrax/geo_works_controller.rb
@@ -1,0 +1,19 @@
+class Hyrax::GeoWorksController < ApplicationController
+  include Hyrax::WorksControllerBehavior
+  include Hyrax::BreadcrumbsForWorks
+  include GeoWorks::GeoblacklightControllerBehavior
+  include Hyrax::GeoMessengerBehavior
+
+  private
+
+    def decorator
+      CompositeDecorator.new(NullDecorator)
+    end
+
+    def curation_concern
+      @decorated_concern ||=
+        begin
+          @curation_concern = decorator.new(@curation_concern)
+        end
+    end
+end

--- a/app/controllers/hyrax/image_works_controller.rb
+++ b/app/controllers/hyrax/image_works_controller.rb
@@ -1,8 +1,7 @@
-class Hyrax::ImageWorksController < ApplicationController
-  include Hyrax::CurationConcernController
+class Hyrax::ImageWorksController < Hyrax::GeoWorksController
   include GeoWorks::ImageWorksControllerBehavior
-  include GeoWorks::GeoblacklightControllerBehavior
-  include Hyrax::GeoMessengerBehavior
+  include Hyrax::Manifest
+  include Hyrax::RemoteMetadata
   self.curation_concern_type = ImageWork
 
   def show_presenter

--- a/app/controllers/hyrax/raster_works_controller.rb
+++ b/app/controllers/hyrax/raster_works_controller.rb
@@ -1,8 +1,6 @@
-class Hyrax::RasterWorksController < ApplicationController
-  include Hyrax::CurationConcernController
+class Hyrax::RasterWorksController < Hyrax::GeoWorksController
   include Hyrax::ParentContainer
   include GeoWorks::RasterWorksControllerBehavior
-  include GeoWorks::GeoblacklightControllerBehavior
   include Hyrax::GeoMessengerBehavior
   self.curation_concern_type = RasterWork
 

--- a/app/controllers/hyrax/vector_works_controller.rb
+++ b/app/controllers/hyrax/vector_works_controller.rb
@@ -1,9 +1,6 @@
-class Hyrax::VectorWorksController < ApplicationController
-  include Hyrax::WorksControllerBehavior
+class Hyrax::VectorWorksController < Hyrax::GeoWorksController
   include Hyrax::ParentContainer
   include GeoWorks::VectorWorksControllerBehavior
-  include GeoWorks::GeoblacklightControllerBehavior
-  include Hyrax::GeoMessengerBehavior
   self.curation_concern_type = VectorWork
 
   def show_presenter

--- a/app/forms/hyrax/image_work_form.rb
+++ b/app/forms/hyrax/image_work_form.rb
@@ -3,6 +3,8 @@ module Hyrax
     include ::GeoWorks::BasicGeoMetadataForm
     include ::GeoWorks::ExternalMetadataFileForm
     self.model_class = ::ImageWork
+    self.terms += [:viewing_direction, :viewing_hint]
+    self.required_fields = [:title, :source_metadata_identifier, :rights_statement, :coverage]
 
     def secondary_terms
       super - [:cartographic_projection]

--- a/app/models/concerns/apply_remote_metadata.rb
+++ b/app/models/concerns/apply_remote_metadata.rb
@@ -1,0 +1,50 @@
+module ApplyRemoteMetadata
+  extend ActiveSupport::Concern
+
+  included do
+    validate :source_metadata_identifier_or_title
+
+    def apply_remote_metadata
+      if remote_data.source
+        self.source_metadata = remote_data.source.dup.try(:force_encoding, 'utf-8')
+      end
+      if remote_data.respond_to?(:jsonld)
+        self.source_jsonld = remote_data.jsonld.dup.try(:force_encoding, 'utf-8')
+      end
+      self.attributes = enumerable_to_single_valued_attributes(remote_data.attributes)
+      CompleteRecord.new(self).complete if workflow_state == 'complete' && identifier.present?
+    end
+
+    private
+
+      def enumerable_to_single_valued_attributes(attributes)
+        attributes.merge(attributes) do |key, value|
+          next unless value
+          single_valued_attributes.include?(key) ? value.first : value
+        end
+      end
+
+      def single_valued_attributes
+        attributes.map { |key, value| key unless value.is_a? Enumerable }.compact
+      end
+
+      def remote_data
+        @remote_data ||= remote_metadata_factory.retrieve(source_metadata_identifier)
+      end
+
+      def remote_metadata_factory
+        if RemoteRecord.bibdata?(source_metadata_identifier) == 0
+          JSONLDRecord::Factory.new(self.class)
+        else
+          RemoteRecord
+        end
+      end
+
+      # Validate that either the source_metadata_identifier or the title is set.
+      def source_metadata_identifier_or_title
+        return if source_metadata_identifier.present? || title.present?
+        errors.add(:title, "You must provide a source metadata id or a title")
+        errors.add(:source_metadata_identifier, "You must provide a source metadata id or a title")
+      end
+  end
+end

--- a/app/models/concerns/common_metadata.rb
+++ b/app/models/concerns/common_metadata.rb
@@ -16,42 +16,8 @@ module CommonMetadata
       ActiveFedora::Indexers::GlobalIndexer.new([:stored_searchable, :symbol])
     )
 
-    validate :source_metadata_identifier_or_title
     validates_with RightsStatementValidator
     validates_with ViewingDirectionValidator
     validates_with ViewingHintValidator
-
-    def apply_remote_metadata
-      if remote_data.source
-        self.source_metadata = remote_data.source.dup.try(:force_encoding, 'utf-8')
-      end
-      if remote_data.respond_to?(:jsonld)
-        self.source_jsonld = remote_data.jsonld.dup.try(:force_encoding, 'utf-8')
-      end
-      self.attributes = remote_data.attributes
-
-      CompleteRecord.new(self).complete if workflow_state == 'complete' && identifier.present?
-    end
-
-    private
-
-    def remote_data
-      @remote_data ||= remote_metadata_factory.retrieve(source_metadata_identifier)
-    end
-
-    def remote_metadata_factory
-      if RemoteRecord.bibdata?(source_metadata_identifier) == 0
-        JSONLDRecord::Factory.new(self.class)
-      else
-        RemoteRecord
-      end
-    end
-
-    # Validate that either the source_metadata_identifier or the title is set.
-    def source_metadata_identifier_or_title
-      return if source_metadata_identifier.present? || title.present?
-      errors.add(:title, "You must provide a source metadata id or a title")
-      errors.add(:source_metadata_identifier, "You must provide a source metadata id or a title")
-    end
   end
 end

--- a/app/models/image_work.rb
+++ b/app/models/image_work.rb
@@ -5,6 +5,7 @@ class ImageWork < ActiveFedora::Base
   include ::GeoWorks::BasicGeoMetadata
   include ::GeoMetadata
   include ::StateBehavior
+  include ::ApplyRemoteMetadata
   self.valid_child_concerns = [RasterWork]
 
   # Use local indexer

--- a/app/models/multi_volume_work.rb
+++ b/app/models/multi_volume_work.rb
@@ -3,6 +3,7 @@ class MultiVolumeWork < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include ::Hyrax::BasicMetadata
   include ::CommonMetadata
+  include ::ApplyRemoteMetadata
   include ::StateBehavior
   include ::StructuralMetadata
   include ::HasPendingUploads

--- a/app/models/scanned_resource.rb
+++ b/app/models/scanned_resource.rb
@@ -4,6 +4,7 @@ class ScannedResource < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include ::Hyrax::BasicMetadata
   include ::CommonMetadata
+  include ::ApplyRemoteMetadata
   include ::StateBehavior
   include ::StructuralMetadata
   include ::HasPendingUploads

--- a/app/presenters/image_work_show_presenter.rb
+++ b/app/presenters/image_work_show_presenter.rb
@@ -1,3 +1,4 @@
 class ImageWorkShowPresenter < GeoWorks::ImageWorkShowPresenter
   include PlumAttributes
+  delegate :viewing_hint, :viewing_direction, :logical_order, :logical_order_object, :ocr_language, to: :solr_document
 end

--- a/app/presenters/vector_work_show_presenter.rb
+++ b/app/presenters/vector_work_show_presenter.rb
@@ -1,5 +1,3 @@
 class VectorWorkShowPresenter < GeoWorks::VectorWorkShowPresenter
   include PlumAttributes
-
-  # self.file_format_service = GeoConcerns::VectorFormatService
 end

--- a/app/schemas/geo_schema.rb
+++ b/app/schemas/geo_schema.rb
@@ -8,4 +8,5 @@ class GeoSchema < ActiveTriples::Schema
   property :source_metadata, predicate: ::PULTerms.source_metadata, multiple: false
   property :holding_location, predicate: ::RDF::Vocab::Bibframe.heldBy, multiple: false
   property :ocr_language, predicate: ::PULTerms.ocr_language
+  property :source_jsonld, predicate: ::PULTerms.source_jsonld, multiple: false
 end

--- a/app/services/plum_derivatives_service.rb
+++ b/app/services/plum_derivatives_service.rb
@@ -10,9 +10,9 @@ class PlumDerivativesService
       filename,
       outputs: [
         label: 'intermediate_file',
+        recipe: recipe,
         service: {
-          datastream: 'intermediate_file',
-          recipe: :default
+          datastream: 'intermediate_file'
         },
         url: derivative_url('intermediate_file')
       ]
@@ -44,5 +44,10 @@ class PlumDerivativesService
     # Override the geo_concerns path factory
     def derivative_path_factory
       PairtreeDerivativePath
+    end
+
+    # Because of issues with tiffs, scanned maps need a seperate recipe
+    def recipe
+      file_set.geo_mime_type && file_set.geo_mime_type == "image/tiff" ? :geo : :default
     end
 end

--- a/app/values/pairtree_derivative_path.rb
+++ b/app/values/pairtree_derivative_path.rb
@@ -12,6 +12,7 @@ class PairtreeDerivativePath < Hyrax::DerivativePath
   def geo_path_prefix
     return unless @object.respond_to?(:geo_mime_type)
     return if @object.geo_mime_type.nil? || @object.geo_mime_type.empty?
+    return if @object.geo_mime_type == "image/tiff"
     Pathname.new(Plum.config[:geo_derivatives_path]).join(pair_path)
   end
 

--- a/app/views/hyrax/image_works/_file_actions.html.erb
+++ b/app/views/hyrax/image_works/_file_actions.html.erb
@@ -1,5 +1,0 @@
-<div class="show-actions">
-  <% if presenter.editor? %>
-      <%= render 'image_actions', document: @presenter %>
-  <% end %>
-</div>

--- a/app/views/hyrax/image_works/_show_actions.html.erb
+++ b/app/views/hyrax/image_works/_show_actions.html.erb
@@ -1,0 +1,19 @@
+<% if collector || editor %>
+  <div class="form-actions">
+    <% if editor %>
+      <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]), class: 'btn btn-default' %>      
+      <div class="btn-group">
+        <button class="btn btn-default btn-small dropdown-toggle" data-toggle="dropdown" href="#"> Attach File <span class="caret"></span></button>
+        <ul class="dropdown-menu">
+          <li>
+            <%= link_to "Attach Image", main_app.new_hyrax_file_set_path(@presenter, type: 'image-data') %>
+          </li>
+          <li>
+            <%= link_to "Attach Metadata", main_app.new_hyrax_file_set_path(@presenter, type: 'metadata') %>
+          </li>
+        </ul>
+      </div>
+    <% end %>
+      <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
+  </div>
+<% end %>

--- a/app/views/hyrax/image_works/show.html.erb
+++ b/app/views/hyrax/image_works/show.html.erb
@@ -1,0 +1,23 @@
+<% provide :page_title, @presenter.page_title %>
+<% provide :page_header do %>
+  <%= render "hyrax/base/title_header" %>
+  <% if @parent_presenter %>
+    <ul class="breadcrumb">
+      <li><%= link_to @parent_presenter, polymorphic_path([main_app, @parent_presenter]) %></li>
+      <li class="active"><%= @presenter.human_readable_type %></li>
+    </ul>
+  <% else %>
+    <span class="human_readable_type">(<%= @presenter.human_readable_type %>)</span>
+  <% end %>
+<% end %>
+
+<% collector = can?(:collect, @presenter.id) %>
+<% editor    = can?(:edit,    @presenter.id) %>
+
+<%= render 'representative_media', presenter: @presenter %>
+<%= render 'geo_works/metadata', presenter: @presenter %>
+<%= render 'geo_works/relationships', presenter: @presenter %>
+<%= render 'geo_works/related/geo_files', presenter: @presenter %>
+<%= render 'geo_works/related/external_metadata_files', presenter: @presenter %>
+<%= render 'workflow_actions', presenter: @presenter if @presenter.workflow.actions.present? %>
+<%= render "show_actions", collector: collector, editor: editor%>

--- a/config/config.yml
+++ b/config/config.yml
@@ -34,6 +34,38 @@ defaults: &defaults
       ORGgen_plt=yes 
       ORGtparts=R 
       Stiles=\{1024,1024\}
+    geo_color: >
+      -no_palette
+      -rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171 
+      -jp2_space sRGB 
+      -double_buffering 10 
+      -num_threads 1 
+      -no_weights 
+      Clevels=6 
+      Clayers=8 
+      Cblk=\{64,64\} 
+      Cuse_sop=yes 
+      Cuse_eph=yes  
+      Corder=RPCL 
+      ORGgen_plt=yes 
+      ORGtparts=R 
+      Stiles=\{1024,1024\}
+    geo_gray: >
+      -no_palette
+      -rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171 
+      -jp2_space sLUM 
+      -double_buffering 10 
+      -num_threads 1
+      -no_weights 
+      Clevels=6 
+      Clayers=8 
+      Cblk=\{64,64\} 
+      Cuse_sop=yes 
+      Cuse_eph=yes  
+      Corder=RPCL 
+      ORGgen_plt=yes 
+      ORGtparts=R 
+      Stiles=\{1024,1024\}
   events:
     server: 'amqp://localhost:5672'
     exchange: 'plum_events'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,11 @@ Rails.application.routes.draw do
         post :browse_everything_files
       end
     end
+    resources :image_works, only: [] do
+      member do
+        get :manifest, defaults: { format: :json }
+      end
+    end
     resources :file_sets, only: [] do
       member do
         post :derivatives

--- a/spec/cassettes/bibdata-maps.yml
+++ b/spec/cassettes/bibdata-maps.yml
@@ -1,0 +1,3715 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/bibliographic/9284317
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Feb 2017 18:32:40 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Request-Method:
+      - GET
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 6c724358-8e40-4d4c-b254-3e568524ddee
+      X-Runtime:
+      - '0.085955'
+      X-Powered-By:
+      - Phusion Passenger 4.0.59
+      Etag:
+      - W/"b7dbdea2bd389e82d1ee92fc113f07a5-gzip"
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1659'
+      Content-Type:
+      - application/xml; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PHJlY29yZCB4bWxucz0naHR0cDovL3d3dy5sb2MuZ292L01BUkMyMS9zbGlt
+        Jz48bGVhZGVyPjAyODgwY2VtIGEyMjAwNjEzN2EgNDUwMDwvbGVhZGVyPjxj
+        b250cm9sZmllbGQgdGFnPScwMDEnPjkyODQzMTc8L2NvbnRyb2xmaWVsZD48
+        Y29udHJvbGZpZWxkIHRhZz0nMDA1Jz4yMDE2MDIyMjE4MjIzOC4wPC9jb250
+        cm9sZmllbGQ+PGNvbnRyb2xmaWVsZCB0YWc9JzAwNic+ZWVrICBiZCBhICBm
+        ICAwICAgPC9jb250cm9sZmllbGQ+PGNvbnRyb2xmaWVsZCB0YWc9JzAwNyc+
+        YWogY2Fuem48L2NvbnRyb2xmaWVsZD48Y29udHJvbGZpZWxkIHRhZz0nMDA4
+        Jz4xNTExMjBzMTk5NCAgICBtZHVlayAgYmQgYSAgZiAgMCAgIGVuZyBkPC9j
+        b250cm9sZmllbGQ+PGRhdGFmaWVsZCBpbmQxPScgJyBpbmQyPScgJyB0YWc9
+        JzA0MCc+PHN1YmZpZWxkIGNvZGU9J2EnPk5qUDwvc3ViZmllbGQ+PHN1YmZp
+        ZWxkIGNvZGU9J2InPmVuZzwvc3ViZmllbGQ+PHN1YmZpZWxkIGNvZGU9J2Un
+        PnJkYTwvc3ViZmllbGQ+PHN1YmZpZWxkIGNvZGU9J2MnPk5qUDwvc3ViZmll
+        bGQ+PC9kYXRhZmllbGQ+PGRhdGFmaWVsZCBpbmQxPScxJyBpbmQyPScgJyB0
+        YWc9JzAzNCc+PHN1YmZpZWxkIGNvZGU9J2EnPmE8L3N1YmZpZWxkPjxzdWJm
+        aWVsZCBjb2RlPSdiJz4yMDAwMDwvc3ViZmllbGQ+PHN1YmZpZWxkIGNvZGU9
+        J2QnPjAwMy45NjY2Njc8L3N1YmZpZWxkPjxzdWJmaWVsZCBjb2RlPSdlJz4w
+        MDQuMzQxNjY3PC9zdWJmaWVsZD48c3ViZmllbGQgY29kZT0nZic+NTIuMDI0
+        MTY3PC9zdWJmaWVsZD48c3ViZmllbGQgY29kZT0nZyc+NTEuOTIwMDAwPC9z
+        dWJmaWVsZD48L2RhdGFmaWVsZD48ZGF0YWZpZWxkIGluZDE9JyAnIGluZDI9
+        JyAnIHRhZz0nMDM3Jz48c3ViZmllbGQgY29kZT0nYSc+MzcgQUhBIDM3MjQy
+        PC9zdWJmaWVsZD48c3ViZmllbGQgY29kZT0nYic+RE1BPC9zdWJmaWVsZD48
+        L2RhdGFmaWVsZD48ZGF0YWZpZWxkIGluZDE9JyAnIGluZDI9JyAnIHRhZz0n
+        MDQzJz48c3ViZmllbGQgY29kZT0nYSc+ZS1uZS0tLTwvc3ViZmllbGQ+PHN1
+        YmZpZWxkIGNvZGU9J2EnPmxuLS0tLS08L3N1YmZpZWxkPjwvZGF0YWZpZWxk
+        PjxkYXRhZmllbGQgaW5kMT0nICcgaW5kMj0nNCcgdGFnPScwNTAnPjxzdWJm
+        aWVsZCBjb2RlPSdhJz5HNjAwMS5QNSBzdmFyLjwvc3ViZmllbGQ+PHN1YmZp
+        ZWxkIGNvZGU9J2InPi5VNSAzNzI0Mjwvc3ViZmllbGQ+PC9kYXRhZmllbGQ+
+        PGRhdGFmaWVsZCBpbmQxPScgJyBpbmQyPScgJyB0YWc9JzA1Mic+PHN1YmZp
+        ZWxkIGNvZGU9J2EnPjYwMDI8L3N1YmZpZWxkPjxzdWJmaWVsZCBjb2RlPSdi
+        Jz5ONTwvc3ViZmllbGQ+PC9kYXRhZmllbGQ+PGRhdGFmaWVsZCBpbmQxPScg
+        JyBpbmQyPScgJyB0YWc9JzA1Mic+PHN1YmZpZWxkIGNvZGU9J2EnPjkxMTI8
+        L3N1YmZpZWxkPjxzdWJmaWVsZCBjb2RlPSdiJz5ONjwvc3ViZmllbGQ+PC9k
+        YXRhZmllbGQ+PGRhdGFmaWVsZCBpbmQxPScgJyBpbmQyPScgJyB0YWc9JzA1
+        Mic+PHN1YmZpZWxkIGNvZGU9J2EnPjYwMDQ8L3N1YmZpZWxkPjxzdWJmaWVs
+        ZCBjb2RlPSdiJz5SNzoyRTk8L3N1YmZpZWxkPjwvZGF0YWZpZWxkPjxkYXRh
+        ZmllbGQgaW5kMT0nICcgaW5kMj0nICcgdGFnPScwNzQnPjxzdWJmaWVsZCBj
+        b2RlPSdhJz4wMzc4LUUtMzI8L3N1YmZpZWxkPjwvZGF0YWZpZWxkPjxkYXRh
+        ZmllbGQgaW5kMT0nMCcgaW5kMj0nICcgdGFnPScwODYnPjxzdWJmaWVsZCBj
+        b2RlPSdhJz5EIDUuMzU2OjM3MjQyLzk5NDwvc3ViZmllbGQ+PC9kYXRhZmll
+        bGQ+PGRhdGFmaWVsZCBpbmQxPScxJyBpbmQyPScgJyB0YWc9JzExMCc+PHN1
+        YmZpZWxkIGNvZGU9J2EnPlVuaXRlZCBTdGF0ZXMuPC9zdWJmaWVsZD48c3Vi
+        ZmllbGQgY29kZT0nYic+RGVmZW5zZSBNYXBwaW5nIEFnZW5jeS48L3N1YmZp
+        ZWxkPjxzdWJmaWVsZCBjb2RlPSdiJz5IeWRyb2dyYXBoaWMvVG9wb2dyYXBo
+        aWMgQ2VudGVyLDwvc3ViZmllbGQ+PHN1YmZpZWxkIGNvZGU9J2UnPmNhcnRv
+        Z3JhcGhlciw8L3N1YmZpZWxkPjxzdWJmaWVsZCBjb2RlPSdlJz5pc3N1aW5n
+        IGJvZHkuPC9zdWJmaWVsZD48L2RhdGFmaWVsZD48ZGF0YWZpZWxkIGluZDE9
+        JzEnIGluZDI9JzAnIHRhZz0nMjQ1Jz48c3ViZmllbGQgY29kZT0nYSc+TmV0
+        aGVybGFuZHMsIE5pZXV3ZSBXYXRlcndlZyBhbmQgRXVyb3Bvb3J0IDo8L3N1
+        YmZpZWxkPjxzdWJmaWVsZCBjb2RlPSdiJz5Ib2VrIFZhbiBIb2xsYW5kIHRv
+        IFZsYWFyZGluZ2VuIC88L3N1YmZpZWxkPjxzdWJmaWVsZCBjb2RlPSdjJz5t
+        b2RpZmllZCByZXByb2R1Y3Rpb24gb2YgSU5UIDE0NzUgb3JpZ2luYWxseSBw
+        dWJsaXNoZWQgQXByaWwgMTk4NSxjb3JyZWN0ZWQgdG8gRGVjZW1iZXIgMTk4
+        NyBieSB0aGUgTmV0aGVybGFuZHMuPC9zdWJmaWVsZD48L2RhdGFmaWVsZD48
+        ZGF0YWZpZWxkIGluZDE9JzMnIGluZDI9JzAnIHRhZz0nMjQ2Jz48c3ViZmll
+        bGQgY29kZT0nYSc+SG9layBWYW4gSG9sbGFuZCB0byBWbGFhcmRpbmdlbjwv
+        c3ViZmllbGQ+PC9kYXRhZmllbGQ+PGRhdGFmaWVsZCBpbmQxPScgJyBpbmQy
+        PScgJyB0YWc9JzI1MCc+PHN1YmZpZWxkIGNvZGU9J2EnPjl0aCBlZC4sIEp1
+        bmUgNCwgMTk5NCAoQ29ycmVjdCB0aHJvdWdoIE5NIDIzLzk0KS48L3N1YmZp
+        ZWxkPjwvZGF0YWZpZWxkPjxkYXRhZmllbGQgaW5kMT0nICcgaW5kMj0nICcg
+        dGFnPScyNTUnPjxzdWJmaWVsZCBjb2RlPSdhJz5TY2FsZSAxOjIwLDAwMCA7
+        PC9zdWJmaWVsZD48c3ViZmllbGQgY29kZT0nYic+TWVyY2F0b3IgcHJvamVj
+        dGlvbjwvc3ViZmllbGQ+PHN1YmZpZWxkIGNvZGU9J2MnPihFIDPCsDU4yrkw
+        MMq6LS1FIDTCsDIwyrkzMMq6L04gNTLCsDAxyrkyN8q6LS1OIDUxwrA1Ncq5
+        MTLKuikuPC9zdWJmaWVsZD48L2RhdGFmaWVsZD48ZGF0YWZpZWxkIGluZDE9
+        JyAnIGluZDI9JzEnIHRhZz0nMjY0Jz48c3ViZmllbGQgY29kZT0nYSc+QmV0
+        aGVzZGEsIE1kLiA6PC9zdWJmaWVsZD48c3ViZmllbGQgY29kZT0nYic+RGVm
+        ZW5zZSBNYXBwaW5nIEFnZW5jeSwgSHlkcm9ncmFwaGljL1RvcG9ncmFwaGlj
+        IENlbnRlciw8L3N1YmZpZWxkPjxzdWJmaWVsZCBjb2RlPSdjJz4xOTk0Ljwv
+        c3ViZmllbGQ+PC9kYXRhZmllbGQ+PGRhdGFmaWVsZCBpbmQxPScgJyBpbmQy
+        PScgJyB0YWc9JzMwMCc+PHN1YmZpZWxkIGNvZGU9J2EnPjEgbWFwIDo8L3N1
+        YmZpZWxkPjxzdWJmaWVsZCBjb2RlPSdiJz5jb2xvciA7PC9zdWJmaWVsZD48
+        c3ViZmllbGQgY29kZT0nYyc+b24gc2hlZXQgNjcgeCAxMDIgY208L3N1YmZp
+        ZWxkPjwvZGF0YWZpZWxkPjxkYXRhZmllbGQgaW5kMT0nICcgaW5kMj0nICcg
+        dGFnPSczMzYnPjxzdWJmaWVsZCBjb2RlPSdhJz5jYXJ0b2dyYXBoaWMgaW1h
+        Z2U8L3N1YmZpZWxkPjxzdWJmaWVsZCBjb2RlPSdiJz5jcmk8L3N1YmZpZWxk
+        PjxzdWJmaWVsZCBjb2RlPScyJz5yZGFjb250ZW50PC9zdWJmaWVsZD48L2Rh
+        dGFmaWVsZD48ZGF0YWZpZWxkIGluZDE9JyAnIGluZDI9JyAnIHRhZz0nMzM3
+        Jz48c3ViZmllbGQgY29kZT0nYSc+dW5tZWRpYXRlZDwvc3ViZmllbGQ+PHN1
+        YmZpZWxkIGNvZGU9J2InPm48L3N1YmZpZWxkPjxzdWJmaWVsZCBjb2RlPScy
+        Jz5yZGFtZWRpYTwvc3ViZmllbGQ+PC9kYXRhZmllbGQ+PGRhdGFmaWVsZCBp
+        bmQxPScgJyBpbmQyPScgJyB0YWc9JzMzOCc+PHN1YmZpZWxkIGNvZGU9J2En
+        PnNoZWV0PC9zdWJmaWVsZD48c3ViZmllbGQgY29kZT0nYic+bmI8L3N1YmZp
+        ZWxkPjxzdWJmaWVsZCBjb2RlPScyJz5yZGFjYXJyaWVyPC9zdWJmaWVsZD48
+        L2RhdGFmaWVsZD48ZGF0YWZpZWxkIGluZDE9JzEnIGluZDI9JyAnIHRhZz0n
+        NDkwJz48c3ViZmllbGQgY29kZT0nYSc+SW50ZXJuYXRpb25hbCBjaGFydCBz
+        ZXJpZXMgOzwvc3ViZmllbGQ+PHN1YmZpZWxkIGNvZGU9J3YnPklOVCAxNDc1
+        PC9zdWJmaWVsZD48L2RhdGFmaWVsZD48ZGF0YWZpZWxkIGluZDE9JyAnIGlu
+        ZDI9JyAnIHRhZz0nNTAwJz48c3ViZmllbGQgY29kZT0nYSc+RGVwdGhzIHNo
+        b3duIGJ5IGlzb2xpbmVzIGFuZCBzb3VuZGluZ3MuPC9zdWJmaWVsZD48L2Rh
+        dGFmaWVsZD48ZGF0YWZpZWxkIGluZDE9JyAnIGluZDI9JyAnIHRhZz0nNTAw
+        Jz48c3ViZmllbGQgY29kZT0nYSc+UmVsaWVmIHNob3duIGJ5IHNwb3QgaGVp
+        Z2h0cy48L3N1YmZpZWxkPjwvZGF0YWZpZWxkPjxkYXRhZmllbGQgaW5kMT0n
+        ICcgaW5kMj0nICcgdGFnPSc1MDAnPjxzdWJmaWVsZCBjb2RlPSdhJz4mcXVv
+        dDtTb3VuZGluZ3MgaW4gbWV0ZXJzLiZxdW90Ozwvc3ViZmllbGQ+PC9kYXRh
+        ZmllbGQ+PGRhdGFmaWVsZCBpbmQxPScgJyBpbmQyPScgJyB0YWc9JzUwMCc+
+        PHN1YmZpZWxkIGNvZGU9J2EnPk1hcCBkcmF3biBpbiAyIHNlZ21lbnRzLjwv
+        c3ViZmllbGQ+PC9kYXRhZmllbGQ+PGRhdGFmaWVsZCBpbmQxPScgJyBpbmQy
+        PScgJyB0YWc9JzUwMCc+PHN1YmZpZWxkIGNvZGU9J2EnPk1hcCBjb250aW51
+        ZWQgaW4gaW5zZXQuPC9zdWJmaWVsZD48L2RhdGFmaWVsZD48ZGF0YWZpZWxk
+        IGluZDE9JyAnIGluZDI9JyAnIHRhZz0nNTA0Jz48c3ViZmllbGQgY29kZT0n
+        YSc+JnF1b3Q7RnJvbSBhIE5ldGhlcmxhbmRzIHN1cnZleXMgMTk4Mi0xOTgz
+        LiZxdW90Ozwvc3ViZmllbGQ+PC9kYXRhZmllbGQ+PGRhdGFmaWVsZCBpbmQx
+        PScgJyBpbmQyPScgJyB0YWc9JzU0Nic+PHN1YmZpZWxkIGNvZGU9J2EnPlBs
+        YWNlIG5hbWVzIGluIER1dGNoIHdpdGggZ2xvc3NhcnkgaW4gRW5nbGlzaC48
+        L3N1YmZpZWxkPjwvZGF0YWZpZWxkPjxkYXRhZmllbGQgaW5kMT0nICcgaW5k
+        Mj0nICcgdGFnPSc1MDAnPjxzdWJmaWVsZCBjb2RlPSdhJz4mcXVvdDtOZXRo
+        ZXJsYW5kcyBjb3B5cmlnaHQgYXBwbGllcy48L3N1YmZpZWxkPjwvZGF0YWZp
+        ZWxkPjxkYXRhZmllbGQgaW5kMT0nMCcgaW5kMj0nICcgdGFnPSc1MDUnPjxz
+        dWJmaWVsZCBjb2RlPSdhJz5bUGFuZWwgQS4gTWFhc3ZsYWt0ZSAtIEV1cm9w
+        b29ydF0gLS0gW1BhbmVsIEIuIFZvb3JuZSAtIFJvemVuYnVyZ108L3N1YmZp
+        ZWxkPjwvZGF0YWZpZWxkPjxkYXRhZmllbGQgaW5kMT0nICcgaW5kMj0nICcg
+        dGFnPSc1MzAnPjxzdWJmaWVsZCBjb2RlPSdhJz5BdmFpbGFibGUgYWxzbyBv
+        bmxpbmUgdGhyb3VnaDo8L3N1YmZpZWxkPjxzdWJmaWVsZCBjb2RlPSdiJz5Q
+        cmluY2V0b24gVW5pdmVyc2l0eSBMaWJyYXJpZXMsIERpZ2l0YWwgTWFwICZh
+        bXA7IEdlb2dyYXBoaWMgRGF0YSBXZWIgc2l0ZS48L3N1YmZpZWxkPjwvZGF0
+        YWZpZWxkPjxkYXRhZmllbGQgaW5kMT0nICcgaW5kMj0nMCcgdGFnPSc2NTEn
+        PjxzdWJmaWVsZCBjb2RlPSdhJz5OZXcgV2F0ZXJ3YXkgKE5ldGhlcmxhbmRz
+        KTwvc3ViZmllbGQ+PHN1YmZpZWxkIGNvZGU9J3gnPk5hdmlnYXRpb24uPC9z
+        dWJmaWVsZD48L2RhdGFmaWVsZD48ZGF0YWZpZWxkIGluZDE9JyAnIGluZDI9
+        JzAnIHRhZz0nNjUxJz48c3ViZmllbGQgY29kZT0nYSc+RXVyb3Bvb3J0IChS
+        b3R0ZXJkYW0sIE5ldGhlcmxhbmRzKTwvc3ViZmllbGQ+PHN1YmZpZWxkIGNv
+        ZGU9J3YnPk1hcHMuPC9zdWJmaWVsZD48L2RhdGFmaWVsZD48ZGF0YWZpZWxk
+        IGluZDE9JyAnIGluZDI9JzAnIHRhZz0nNjUxJz48c3ViZmllbGQgY29kZT0n
+        YSc+Tm9ydGggU2VhPC9zdWJmaWVsZD48c3ViZmllbGQgY29kZT0neCc+TmF2
+        aWdhdGlvbi48L3N1YmZpZWxkPjwvZGF0YWZpZWxkPjxkYXRhZmllbGQgaW5k
+        MT0nICcgaW5kMj0nNycgdGFnPSc2NTAnPjxzdWJmaWVsZCBjb2RlPSdhJz5O
+        YXZpZ2F0aW9uLjwvc3ViZmllbGQ+PHN1YmZpZWxkIGNvZGU9JzInPmZhc3Q8
+        L3N1YmZpZWxkPjxzdWJmaWVsZCBjb2RlPScwJz4oT0NvTEMpZnN0MDEwMzUw
+        ODU8L3N1YmZpZWxkPjwvZGF0YWZpZWxkPjxkYXRhZmllbGQgaW5kMT0nICcg
+        aW5kMj0nNycgdGFnPSc2NTEnPjxzdWJmaWVsZCBjb2RlPSdhJz5BdGxhbnRp
+        YyBPY2Vhbjwvc3ViZmllbGQ+PHN1YmZpZWxkIGNvZGU9J3onPk5vcnRoIFNl
+        YS48L3N1YmZpZWxkPjxzdWJmaWVsZCBjb2RlPScyJz5mYXN0PC9zdWJmaWVs
+        ZD48c3ViZmllbGQgY29kZT0nMCc+KE9Db0xDKWZzdDAxMjQyNTA0PC9zdWJm
+        aWVsZD48L2RhdGFmaWVsZD48ZGF0YWZpZWxkIGluZDE9JyAnIGluZDI9Jzcn
+        IHRhZz0nNjUxJz48c3ViZmllbGQgY29kZT0nYSc+TmV0aGVybGFuZHM8L3N1
+        YmZpZWxkPjxzdWJmaWVsZCBjb2RlPSd6Jz5OZXcgV2F0ZXJ3YXkuPC9zdWJm
+        aWVsZD48c3ViZmllbGQgY29kZT0nMic+ZmFzdDwvc3ViZmllbGQ+PHN1YmZp
+        ZWxkIGNvZGU9JzAnPihPQ29MQylmc3QwMTI0NDg4NTwvc3ViZmllbGQ+PC9k
+        YXRhZmllbGQ+PGRhdGFmaWVsZCBpbmQxPScgJyBpbmQyPSc3JyB0YWc9JzY1
+        MSc+PHN1YmZpZWxkIGNvZGU9J2EnPk5ldGhlcmxhbmRzPC9zdWJmaWVsZD48
+        c3ViZmllbGQgY29kZT0neic+Um90dGVyZGFtPC9zdWJmaWVsZD48c3ViZmll
+        bGQgY29kZT0neic+RXVyb3Bvb3J0Ljwvc3ViZmllbGQ+PHN1YmZpZWxkIGNv
+        ZGU9JzInPmZhc3Q8L3N1YmZpZWxkPjxzdWJmaWVsZCBjb2RlPScwJz4oT0Nv
+        TEMpZnN0MDEzMjE4MTI8L3N1YmZpZWxkPjwvZGF0YWZpZWxkPjxkYXRhZmll
+        bGQgaW5kMT0nICcgaW5kMj0nNycgdGFnPSc2NTEnPjxzdWJmaWVsZCBjb2Rl
+        PSdhJz5OZXRoZXJsYW5kczwvc3ViZmllbGQ+PHN1YmZpZWxkIGNvZGU9J3on
+        PlJvdHRlcmRhbSBSZWdpb24uPC9zdWJmaWVsZD48c3ViZmllbGQgY29kZT0n
+        Mic+ZmFzdDwvc3ViZmllbGQ+PHN1YmZpZWxkIGNvZGU9JzAnPihPQ29MQylm
+        c3QwMTM0NzcxNzwvc3ViZmllbGQ+PC9kYXRhZmllbGQ+PGRhdGFmaWVsZCBp
+        bmQxPScgJyBpbmQyPSc3JyB0YWc9JzY1NSc+PHN1YmZpZWxkIGNvZGU9J2En
+        Pk5hdXRpY2FsIGNoYXJ0czwvc3ViZmllbGQ+PHN1YmZpZWxkIGNvZGU9JzIn
+        PmZhc3Q8L3N1YmZpZWxkPjxzdWJmaWVsZCBjb2RlPScwJz4oT0NvTEMpZnN0
+        MDEwMzQ3NjI8L3N1YmZpZWxkPjwvZGF0YWZpZWxkPjxkYXRhZmllbGQgaW5k
+        MT0nICcgaW5kMj0nNycgdGFnPSc2NTUnPjxzdWJmaWVsZCBjb2RlPSdhJz5O
+        YXV0aWNhbCBjaGFydHMuPC9zdWJmaWVsZD48c3ViZmllbGQgY29kZT0nMic+
+        bGNnZnQ8L3N1YmZpZWxkPjwvZGF0YWZpZWxkPjxkYXRhZmllbGQgaW5kMT0n
+        ICcgaW5kMj0nMCcgdGFnPSc4MzAnPjxzdWJmaWVsZCBjb2RlPSdhJz5JbnRl
+        cm5hdGlvbmFsIGNoYXJ0IHNlcmllcyA7PC9zdWJmaWVsZD48c3ViZmllbGQg
+        Y29kZT0ndic+SU5UIDE0NzUuPC9zdWJmaWVsZD48L2RhdGFmaWVsZD48ZGF0
+        YWZpZWxkIGluZDE9JzQnIGluZDI9JzEnIHRhZz0nODU2Jz48c3ViZmllbGQg
+        Y29kZT0neic+U2VlIHRoZSBtYXA8L3N1YmZpZWxkPjxzdWJmaWVsZCBjb2Rl
+        PSd1Jz5odHRwOi8vYXJrcy5wcmluY2V0b24uZWR1L2FyazovODg0MzUvdjQw
+        NXNkMDFqPC9zdWJmaWVsZD48L2RhdGFmaWVsZD48ZGF0YWZpZWxkIGluZDE9
+        JzgnIGluZDI9JyAnIHRhZz0nODUyJz48c3ViZmllbGQgY29kZT0nMCc+OTE0
+        OTU0NDwvc3ViZmllbGQ+PHN1YmZpZWxkIGNvZGU9J2InPnNjaW1hcDwvc3Vi
+        ZmllbGQ+PHN1YmZpZWxkIGNvZGU9J2gnPkc2MDAyLk42UDUgc3Zhci48L3N1
+        YmZpZWxkPjxzdWJmaWVsZCBjb2RlPSdpJz4uVTUgMzcyNDI8L3N1YmZpZWxk
+        PjxzdWJmaWVsZCBjb2RlPSd6Jz5DaGFydCBpcyBsb2NhdGVkIGluIE1hcCBB
+        bm5leC4gQ2FsbCBudW1iZXIgU3VEb2Mgbm8uIDogRCA1LjM1NjozNzI0MS85
+        OTQ8L3N1YmZpZWxkPjwvZGF0YWZpZWxkPjwvcmVjb3JkPg==
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 18:32:40 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/bibliographic/9284317/jsonld
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/turtle, text/rdf+turtle, application/turtle;q=0.2, application/x-turtle;q=0.2,
+        application/ld+json, application/x-ld+json, application/n-triples, text/plain;q=0.2,
+        */*;q=0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Feb 2017 18:32:41 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Request-Method:
+      - GET
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 7f42db05-00ff-422b-ac44-57fc3f9bbaab
+      X-Runtime:
+      - '0.334725'
+      X-Powered-By:
+      - Phusion Passenger 4.0.59
+      Etag:
+      - W/"aa2132601c8d1affa7b0221ff7943862"
+      Status:
+      - 200 OK
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/ld+json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJAY29udGV4dCI6Imh0dHA6Ly9iaWJkYXRhLnByaW5jZXRvbi5lZHUvY29u
+        dGV4dC5qc29uIiwiQGlkIjoiaHR0cDovL2JpYmRhdGEucHJpbmNldG9uLmVk
+        dS9iaWJsaW9ncmFwaGljLzkyODQzMTciLCJ0aXRsZSI6eyJAdmFsdWUiOiJO
+        ZXRoZXJsYW5kcywgTmlldXdlIFdhdGVyd2VnIGFuZCBFdXJvcG9vcnQgOiBI
+        b2VrIFZhbiBIb2xsYW5kIHRvIFZsYWFyZGluZ2VuIiwiQGxhbmd1YWdlIjoi
+        ZW5nIn0sImxhbmd1YWdlIjoiZW5nIiwiY3JlYXRvciI6IlVuaXRlZCBTdGF0
+        ZXMuIERlZmVuc2UgTWFwcGluZyBBZ2VuY3kuIEh5ZHJvZ3JhcGhpYy9Ub3Bv
+        Z3JhcGhpYyBDZW50ZXIiLCJjYWxsX251bWJlciI6Ikc2MDAyLk42UDUgc3Zh
+        ci4gLlU1IDM3MjQyIiwiZXh0ZW50IjpbIlNjYWxlIDE6MjAsMDAwIDsgTWVy
+        Y2F0b3IgcHJvamVjdGlvbiAoRSAzwrA1OMq5MDDKui0tRSA0wrAyMMq5MzDK
+        ui9OIDUywrAwMcq5MjfKui0tTiA1McKwNTXKuTEyyropLiIsIjEgbWFwIDog
+        Y29sb3IgOyBvbiBzaGVldCA2NyB4IDEwMiBjbSJdLCJlZGl0aW9uIjoiOXRo
+        IGVkLiwgSnVuZSA0LCAxOTk0IChDb3JyZWN0IHRocm91Z2ggTk0gMjMvOTQp
+        LiIsImZvcm1hdCI6Ik1hcCIsInR5cGUiOiJNYXBzIiwiZGVzY3JpcHRpb24i
+        OlsiRGVwdGhzIHNob3duIGJ5IGlzb2xpbmVzIGFuZCBzb3VuZGluZ3MuIiwi
+        UmVsaWVmIHNob3duIGJ5IHNwb3QgaGVpZ2h0cy4iLCJcIlNvdW5kaW5ncyBp
+        biBtZXRlcnMuXCIiLCJNYXAgZHJhd24gaW4gMiBzZWdtZW50cy4iLCJNYXAg
+        Y29udGludWVkIGluIGluc2V0LiIsIlwiTmV0aGVybGFuZHMgY29weXJpZ2h0
+        IGFwcGxpZXMuIl0sInB1Ymxpc2hlciI6IkJldGhlc2RhLCBNZC4gOiBEZWZl
+        bnNlIE1hcHBpbmcgQWdlbmN5LCBIeWRyb2dyYXBoaWMvVG9wb2dyYXBoaWMg
+        Q2VudGVyLCAxOTk0LiIsInN1YmplY3QiOlsiTmV3IFdhdGVyd2F5IChOZXRo
+        ZXJsYW5kcynigJROYXZpZ2F0aW9uIiwiRXVyb3Bvb3J0IChSb3R0ZXJkYW0s
+        IE5ldGhlcmxhbmRzKeKAlE1hcHMiLCJOb3J0aCBTZWHigJROYXZpZ2F0aW9u
+        Il0sImNvdmVyYWdlIjoibm9ydGhsaW1pdD01Mi4wMjQxNjc7IGVhc3RsaW1p
+        dD0wMDQuMzQxNjY3OyBzb3V0aGxpbWl0PTUxLjkyMDAwMDsgd2VzdGxpbWl0
+        PTAwMy45NjY2Njc7IHVuaXRzPWRlZ3JlZXM7IHByb2plY3Rpb249RVBTRzo0
+        MzI2IiwiY2FydG9ncmFwaGVyIjoiVW5pdGVkIFN0YXRlcy4gRGVmZW5zZSBN
+        YXBwaW5nIEFnZW5jeS4gSHlkcm9ncmFwaGljL1RvcG9ncmFwaGljIENlbnRl
+        ciIsImNyZWF0ZWQiOiIxOTk0LTAxLTAxVDAwOjAwOjAwWiIsImRhdGUiOiIx
+        OTk0In0=
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 18:32:41 GMT
+- request:
+    method: get
+    uri: http://bibdata.princeton.edu/context.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Date:
+      - Thu, 23 Feb 2017 18:32:41 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Location:
+      - https://bibdata.princeton.edu/context.json
+      Content-Length:
+      - '312'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>302 Found</title>
+        </head><body>
+        <h1>Found</h1>
+        <p>The document has moved <a href="https://bibdata.princeton.edu/context.json">here</a>.</p>
+        <hr>
+        <address>Apache/2.4.7 (Ubuntu) Server at bibdata.princeton.edu Port 80</address>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 18:32:41 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/context.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Feb 2017 18:32:42 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Last-Modified:
+      - Thu, 23 Feb 2017 17:53:44 GMT
+      Etag:
+      - '"73ba-549364b4dba00"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '29626'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "@context": {
+            "id" : "@id",
+            "bf": "http://id.loc.gov/ontologies/bibframe/",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "mrel": "http://id.loc.gov/vocabulary/relators/",
+            "pulterms": "http://library.princeton.edu/terms/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+
+            "contributor": {"@id": "dc:contributor"},
+            "coverage": {"@id": "dc:coverage"},
+            "creator": {"@id": "dc:creator"},
+            "date": {"@id": "dc:date"},
+            "description": {"@id": "dc:description"},
+            "format": {"@id": "dc:format"},
+            "identifier": {"@id": "dc:identifier"},
+            "language": {"@id": "dc:language"},
+            "publisher": {"@id": "dc:publisher"},
+            "relation": {"@id": "dc:relation"},
+            "rights": {"@id": "dc:rights"},
+            "source": {"@id": "dc:source"},
+            "subject": {"@id": "dc:subject"},
+            "type": {"@id": "dc:type"},
+
+            "created": {"@id": "dcterms:created"},
+            "extent": {"@id": "dcterms:extent"},
+            "modified": {"@id": "dcterms:modified"},
+            "title": {"@id": "dcterms:title"},
+
+            "edition": {"@id": "bf:editionStatement"},
+            "call_number": {"@id": "pulterms:call_number"},
+
+            "abridger": {
+              "@id": "mrel:abr"
+            },
+            "actor": {
+              "@id": "mrel:act"
+            },
+            "adapter": {
+              "@id": "mrel:adp"
+            },
+            "addressee": {
+              "@id": "mrel:rcp"
+            },
+            "analyst": {
+              "@id": "mrel:anl"
+            },
+            "animator": {
+              "@id": "mrel:anm"
+            },
+            "annotator": {
+              "@id": "mrel:ann"
+            },
+            "appellant": {
+              "@id": "mrel:apl"
+            },
+            "appellee": {
+              "@id": "mrel:ape"
+            },
+            "applicant": {
+              "@id": "mrel:app"
+            },
+            "architect": {
+              "@id": "mrel:arc"
+            },
+            "arranger": {
+              "@id": "mrel:arr"
+            },
+            "art_copyist": {
+              "@id": "mrel:acp"
+            },
+            "art_director": {
+              "@id": "mrel:adi"
+            },
+            "artist": {
+              "@id": "mrel:art"
+            },
+            "artistic_director": {
+              "@id": "mrel:ard"
+            },
+            "assignee": {
+              "@id": "mrel:asg"
+            },
+            "associated_name": {
+              "@id": "mrel:asn"
+            },
+            "attributed_name": {
+              "@id": "mrel:att"
+            },
+            "auctioneer": {
+              "@id": "mrel:auc"
+            },
+            "author": {
+              "@id": "mrel:aut"
+            },
+            "author_in_quotations_or_text_abstracts": {
+              "@id": "mrel:aqt"
+            },
+            "author_of_afterword_colophon_etc": {
+              "@id": "mrel:aft"
+            },
+            "author_of_dialog": {
+              "@id": "mrel:aud"
+            },
+            "author_of_introduction_etc": {
+              "@id": "mrel:aui"
+            },
+            "autographer": {
+              "@id": "mrel:ato"
+            },
+            "bibliographic_antecedent": {
+              "@id": "mrel:ant"
+            },
+            "binder": {
+              "@id": "mrel:bnd"
+            },
+            "binding_designer": {
+              "@id": "mrel:bdd"
+            },
+            "blurb_writer": {
+              "@id": "mrel:blw"
+            },
+            "book_designer": {
+              "@id": "mrel:bkd"
+            },
+            "book_producer": {
+              "@id": "mrel:bkp"
+            },
+            "bookjacket_designer": {
+              "@id": "mrel:bjd"
+            },
+            "bookplate_designer": {
+              "@id": "mrel:bpd"
+            },
+            "bookseller": {
+              "@id": "mrel:bsl"
+            },
+            "braille_embosser": {
+              "@id": "mrel:brl"
+            },
+            "broadcaster": {
+              "@id": "mrel:brd"
+            },
+            "calligrapher": {
+              "@id": "mrel:cll"
+            },
+            "cartographer": {
+              "@id": "mrel:ctg"
+            },
+            "caster": {
+              "@id": "mrel:cas"
+            },
+            "censor": {
+              "@id": "mrel:cns"
+            },
+            "choreographer": {
+              "@id": "mrel:chr"
+            },
+            "cinematographer": {
+              "@id": "mrel:cng"
+            },
+            "client": {
+              "@id": "mrel:cli"
+            },
+            "collection_registrar": {
+              "@id": "mrel:cor"
+            },
+            "collector": {
+              "@id": "mrel:col"
+            },
+            "collotyper": {
+              "@id": "mrel:clt"
+            },
+            "colorist": {
+              "@id": "mrel:clr"
+            },
+            "commentator": {
+              "@id": "mrel:cmm"
+            },
+            "commentator_for_written_text": {
+              "@id": "mrel:cwt"
+            },
+            "compiler": {
+              "@id": "mrel:com"
+            },
+            "complainant": {
+              "@id": "mrel:cpl"
+            },
+            "complainant_appellant": {
+              "@id": "mrel:cpt"
+            },
+            "complainant_appellee": {
+              "@id": "mrel:cpe"
+            },
+            "composer": {
+              "@id": "mrel:cmp"
+            },
+            "compositor": {
+              "@id": "mrel:cmt"
+            },
+            "conceptor": {
+              "@id": "mrel:ccp"
+            },
+            "conductor": {
+              "@id": "mrel:cnd"
+            },
+            "conservator": {
+              "@id": "mrel:con"
+            },
+            "consultant": {
+              "@id": "mrel:csl"
+            },
+            "consultant_to_a_project": {
+              "@id": "mrel:csp"
+            },
+            "contestant": {
+              "@id": "mrel:cos"
+            },
+            "contestant_appellant": {
+              "@id": "mrel:cot"
+            },
+            "contestant_appellee": {
+              "@id": "mrel:coe"
+            },
+            "contestee": {
+              "@id": "mrel:cts"
+            },
+            "contestee_appellant": {
+              "@id": "mrel:ctt"
+            },
+            "contestee_appellee": {
+              "@id": "mrel:cte"
+            },
+            "contractor": {
+              "@id": "mrel:ctr"
+            },
+            "copyright_claimant": {
+              "@id": "mrel:cpc"
+            },
+            "copyright_holder": {
+              "@id": "mrel:cph"
+            },
+            "corrector": {
+              "@id": "mrel:crr"
+            },
+            "correspondent": {
+              "@id": "mrel:crp"
+            },
+            "costume_designer": {
+              "@id": "mrel:cst"
+            },
+            "court_governed": {
+              "@id": "mrel:cou"
+            },
+            "court_reporter": {
+              "@id": "mrel:crt"
+            },
+            "cover_designer": {
+              "@id": "mrel:cov"
+            },
+            "curator": {
+              "@id": "mrel:cur"
+            },
+            "dancer": {
+              "@id": "mrel:dnc"
+            },
+            "data_contributor": {
+              "@id": "mrel:dtc"
+            },
+            "data_manager": {
+              "@id": "mrel:dtm"
+            },
+            "dedicatee": {
+              "@id": "mrel:dte"
+            },
+            "dedicator": {
+              "@id": "mrel:dto"
+            },
+            "defendant": {
+              "@id": "mrel:dfd"
+            },
+            "defendant_appellant": {
+              "@id": "mrel:dft"
+            },
+            "defendant_appellee": {
+              "@id": "mrel:dfe"
+            },
+            "degree_granting_institution": {
+              "@id": "mrel:dgg"
+            },
+            "degree_supervisor": {
+              "@id": "mrel:dgs"
+            },
+            "delineator": {
+              "@id": "mrel:dln"
+            },
+            "depicted": {
+              "@id": "mrel:dpc"
+            },
+            "depositor": {
+              "@id": "mrel:dpt"
+            },
+            "designer": {
+              "@id": "mrel:dsr"
+            },
+            "director": {
+              "@id": "mrel:drt"
+            },
+            "dissertant": {
+              "@id": "mrel:dis"
+            },
+            "distribution_place": {
+              "@id": "mrel:dbp"
+            },
+            "distributor": {
+              "@id": "mrel:dst"
+            },
+            "donor": {
+              "@id": "mrel:dnr"
+            },
+            "draftsman": {
+              "@id": "mrel:drm"
+            },
+            "dubious_author": {
+              "@id": "mrel:dub"
+            },
+            "editor": {
+              "@id": "mrel:edt"
+            },
+            "editor_of_compilation": {
+              "@id": "mrel:edc"
+            },
+            "editor_of_moving_image_work": {
+              "@id": "mrel:edm"
+            },
+            "electrician": {
+              "@id": "mrel:elg"
+            },
+            "electrotyper": {
+              "@id": "mrel:elt"
+            },
+            "enacting_jurisdiction": {
+              "@id": "mrel:enj"
+            },
+            "engineer": {
+              "@id": "mrel:eng"
+            },
+            "engraver": {
+              "@id": "mrel:egr"
+            },
+            "etcher": {
+              "@id": "mrel:etr"
+            },
+            "event_place": {
+              "@id": "mrel:evp"
+            },
+            "expert": {
+              "@id": "mrel:exp"
+            },
+            "facsimilist": {
+              "@id": "mrel:fac"
+            },
+            "field_director": {
+              "@id": "mrel:fld"
+            },
+            "film_distributor": {
+              "@id": "mrel:fds"
+            },
+            "film_director": {
+              "@id": "mrel:fmd"
+            },
+            "film_editor": {
+              "@id": "mrel:flm"
+            },
+            "film_producer": {
+              "@id": "mrel:fmp"
+            },
+            "filmmaker": {
+              "@id": "mrel:fmk"
+            },
+            "first_party": {
+              "@id": "mrel:fpy"
+            },
+            "forger": {
+              "@id": "mrel:frg"
+            },
+            "former_owner": {
+              "@id": "mrel:fmo"
+            },
+            "funder": {
+              "@id": "mrel:fnd"
+            },
+            "geographic_information_specialist": {
+              "@id": "mrel:gis"
+            },
+            "honoree": {
+              "@id": "mrel:hnr"
+            },
+            "host": {
+              "@id": "mrel:hst"
+            },
+            "host_institution": {
+              "@id": "mrel:his"
+            },
+            "illuminator": {
+              "@id": "mrel:ilu"
+            },
+            "illustrator": {
+              "@id": "mrel:ill"
+            },
+            "inscriber": {
+              "@id": "mrel:ins"
+            },
+            "instrumentalist": {
+              "@id": "mrel:itr"
+            },
+            "interviewee": {
+              "@id": "mrel:ive"
+            },
+            "interviewer": {
+              "@id": "mrel:ivr"
+            },
+            "inventor": {
+              "@id": "mrel:inv"
+            },
+            "issuing_body": {
+              "@id": "mrel:isb"
+            },
+            "judge": {
+              "@id": "mrel:jud"
+            },
+            "jurisdiction_governed": {
+              "@id": "mrel:jug"
+            },
+            "laboratory": {
+              "@id": "mrel:lbr"
+            },
+            "laboratory_director": {
+              "@id": "mrel:ldr"
+            },
+            "landscape_architect": {
+              "@id": "mrel:lsa"
+            },
+            "lead": {
+              "@id": "mrel:led"
+            },
+            "lender": {
+              "@id": "mrel:len"
+            },
+            "libelant": {
+              "@id": "mrel:lil"
+            },
+            "libelant_appellant": {
+              "@id": "mrel:lit"
+            },
+            "libelant_appellee": {
+              "@id": "mrel:lie"
+            },
+            "libelee": {
+              "@id": "mrel:lel"
+            },
+            "libelee_appellant": {
+              "@id": "mrel:let"
+            },
+            "libelee_appellee": {
+              "@id": "mrel:lee"
+            },
+            "librettist": {
+              "@id": "mrel:lbt"
+            },
+            "licensee": {
+              "@id": "mrel:lse"
+            },
+            "licensor": {
+              "@id": "mrel:lso"
+            },
+            "lighting_designer": {
+              "@id": "mrel:lgd"
+            },
+            "lithographer": {
+              "@id": "mrel:ltg"
+            },
+            "lyricist": {
+              "@id": "mrel:lyr"
+            },
+            "manufacture_place": {
+              "@id": "mrel:mfp"
+            },
+            "manufacturer": {
+              "@id": "mrel:mfr"
+            },
+            "marbler": {
+              "@id": "mrel:mrb"
+            },
+            "markup_editor": {
+              "@id": "mrel:mrk"
+            },
+            "medium": {
+              "@id": "mrel:med"
+            },
+            "metadata_contact": {
+              "@id": "mrel:mdc"
+            },
+            "metal_engraver": {
+              "@id": "mrel:mte"
+            },
+            "minute_taker": {
+              "@id": "mrel:mtk"
+            },
+            "moderator": {
+              "@id": "mrel:mod"
+            },
+            "monitor": {
+              "@id": "mrel:mon"
+            },
+            "music_copyist": {
+              "@id": "mrel:mcp"
+            },
+            "musical_director": {
+              "@id": "mrel:msd"
+            },
+            "musician": {
+              "@id": "mrel:mus"
+            },
+            "narrator": {
+              "@id": "mrel:nrt"
+            },
+            "onscreen_presenter": {
+              "@id": "mrel:osp"
+            },
+            "opponent": {
+              "@id": "mrel:opn"
+            },
+            "organizer": {
+              "@id": "mrel:orm"
+            },
+            "originator": {
+              "@id": "mrel:org"
+            },
+            "other": {
+              "@id": "mrel:oth"
+            },
+            "owner": {
+              "@id": "mrel:own"
+            },
+            "panelist": {
+              "@id": "mrel:pan"
+            },
+            "papermaker": {
+              "@id": "mrel:ppm"
+            },
+            "patent_applicant": {
+              "@id": "mrel:pta"
+            },
+            "patent_holder": {
+              "@id": "mrel:pth"
+            },
+            "patron": {
+              "@id": "mrel:pat"
+            },
+            "performer": {
+              "@id": "mrel:prf"
+            },
+            "permitting_agency": {
+              "@id": "mrel:pma"
+            },
+            "photographer": {
+              "@id": "mrel:pht"
+            },
+            "plaintiff": {
+              "@id": "mrel:ptf"
+            },
+            "plaintiff_appellant": {
+              "@id": "mrel:ptt"
+            },
+            "plaintiff_appellee": {
+              "@id": "mrel:pte"
+            },
+            "platemaker": {
+              "@id": "mrel:plt"
+            },
+            "praeses": {
+              "@id": "mrel:pra"
+            },
+            "presenter": {
+              "@id": "mrel:pre"
+            },
+            "printer": {
+              "@id": "mrel:prt"
+            },
+            "printer_of_plates": {
+              "@id": "mrel:pop"
+            },
+            "printmaker": {
+              "@id": "mrel:prm"
+            },
+            "process_contact": {
+              "@id": "mrel:prc"
+            },
+            "producer": {
+              "@id": "mrel:pro"
+            },
+            "production_company": {
+              "@id": "mrel:prn"
+            },
+            "production_designer": {
+              "@id": "mrel:prs"
+            },
+            "production_manager": {
+              "@id": "mrel:pmn"
+            },
+            "production_personnel": {
+              "@id": "mrel:prd"
+            },
+            "production_place": {
+              "@id": "mrel:prp"
+            },
+            "programmer": {
+              "@id": "mrel:prg"
+            },
+            "project_director": {
+              "@id": "mrel:pdr"
+            },
+            "proofreader": {
+              "@id": "mrel:pfr"
+            },
+            "provider": {
+              "@id": "mrel:prv"
+            },
+            "publication_place": {
+              "@id": "mrel:pup"
+            },
+            "publishing_director": {
+              "@id": "mrel:pbd"
+            },
+            "puppeteer": {
+              "@id": "mrel:ppt"
+            },
+            "radio_director": {
+              "@id": "mrel:rdd"
+            },
+            "radio_producer": {
+              "@id": "mrel:rpc"
+            },
+            "recording_engineer": {
+              "@id": "mrel:rce"
+            },
+            "recordist": {
+              "@id": "mrel:rcd"
+            },
+            "redaktor": {
+              "@id": "mrel:red"
+            },
+            "renderer": {
+              "@id": "mrel:ren"
+            },
+            "reporter": {
+              "@id": "mrel:rpt"
+            },
+            "repository": {
+              "@id": "mrel:rps"
+            },
+            "research_team_head": {
+              "@id": "mrel:rth"
+            },
+            "research_team_member": {
+              "@id": "mrel:rtm"
+            },
+            "researcher": {
+              "@id": "mrel:res"
+            },
+            "respondent": {
+              "@id": "mrel:rsp"
+            },
+            "respondent_appellant": {
+              "@id": "mrel:rst"
+            },
+            "respondent_appellee": {
+              "@id": "mrel:rse"
+            },
+            "responsible_party": {
+              "@id": "mrel:rpy"
+            },
+            "restager": {
+              "@id": "mrel:rsg"
+            },
+            "restorationist": {
+              "@id": "mrel:rsr"
+            },
+            "reviewer": {
+              "@id": "mrel:rev"
+            },
+            "rubricator": {
+              "@id": "mrel:rbr"
+            },
+            "scenarist": {
+              "@id": "mrel:sce"
+            },
+            "scientific_advisor": {
+              "@id": "mrel:sad"
+            },
+            "screenwriter": {
+              "@id": "mrel:aus"
+            },
+            "scribe": {
+              "@id": "mrel:scr"
+            },
+            "sculptor": {
+              "@id": "mrel:scl"
+            },
+            "second_party": {
+              "@id": "mrel:spy"
+            },
+            "secretary": {
+              "@id": "mrel:sec"
+            },
+            "seller": {
+              "@id": "mrel:sll"
+            },
+            "set_designer": {
+              "@id": "mrel:std"
+            },
+            "setting": {
+              "@id": "mrel:stg"
+            },
+            "signer": {
+              "@id": "mrel:sgn"
+            },
+            "singer": {
+              "@id": "mrel:sng"
+            },
+            "sound_designer": {
+              "@id": "mrel:sds"
+            },
+            "speaker": {
+              "@id": "mrel:spk"
+            },
+            "sponsor": {
+              "@id": "mrel:spn"
+            },
+            "stage_director": {
+              "@id": "mrel:sgd"
+            },
+            "stage_manager": {
+              "@id": "mrel:stm"
+            },
+            "standards_body": {
+              "@id": "mrel:stn"
+            },
+            "stereotyper": {
+              "@id": "mrel:str"
+            },
+            "storyteller": {
+              "@id": "mrel:stl"
+            },
+            "supporting_host": {
+              "@id": "mrel:sht"
+            },
+            "surveyor": {
+              "@id": "mrel:srv"
+            },
+            "teacher": {
+              "@id": "mrel:tch"
+            },
+            "technical_director": {
+              "@id": "mrel:tcd"
+            },
+            "television_director": {
+              "@id": "mrel:tld"
+            },
+            "television_producer": {
+              "@id": "mrel:tlp"
+            },
+            "thesis_advisor": {
+              "@id": "mrel:ths"
+            },
+            "transcriber": {
+              "@id": "mrel:trc"
+            },
+            "translator": {
+              "@id": "mrel:trl"
+            },
+            "type_designer": {
+              "@id": "mrel:tyd"
+            },
+            "typographer": {
+              "@id": "mrel:tyg"
+            },
+            "university_place": {
+              "@id": "mrel:uvp"
+            },
+            "videographer": {
+              "@id": "mrel:vdg"
+            },
+            "voice_actor": {
+              "@id": "mrel:vac"
+            },
+            "witness": {
+              "@id": "mrel:wit"
+            },
+            "wood_engraver": {
+              "@id": "mrel:wde"
+            },
+            "woodcutter": {
+              "@id": "mrel:wdc"
+            },
+            "writer_of_accompanying_material": {
+              "@id": "mrel:wam"
+            },
+            "writer_of_added_commentary": {
+              "@id": "mrel:wac"
+            },
+            "writer_of_added_text": {
+              "@id": "mrel:wat"
+            },
+            "writer_of_added_lyrics": {
+              "@id": "mrel:wal"
+            },
+            "writer_of_supplementary_textual_content": {
+              "@id": "mrel:wst"
+            },
+            "writer_of_introduction": {
+              "@id": "mrel:win"
+            },
+            "writer_of_preface": {
+              "@id": "mrel:wpr"
+            },
+            "abridger": {
+              "@id": "mrel:abr"
+            },
+            "actor": {
+              "@id": "mrel:act"
+            },
+            "adapter": {
+              "@id": "mrel:adp"
+            },
+            "addressee": {
+              "@id": "mrel:rcp"
+            },
+            "analyst": {
+              "@id": "mrel:anl"
+            },
+            "animator": {
+              "@id": "mrel:anm"
+            },
+            "annotator": {
+              "@id": "mrel:ann"
+            },
+            "appellant": {
+              "@id": "mrel:apl"
+            },
+            "appellee": {
+              "@id": "mrel:ape"
+            },
+            "applicant": {
+              "@id": "mrel:app"
+            },
+            "architect": {
+              "@id": "mrel:arc"
+            },
+            "arranger": {
+              "@id": "mrel:arr"
+            },
+            "art_copyist": {
+              "@id": "mrel:acp"
+            },
+            "art_director": {
+              "@id": "mrel:adi"
+            },
+            "artist": {
+              "@id": "mrel:art"
+            },
+            "artistic_director": {
+              "@id": "mrel:ard"
+            },
+            "assignee": {
+              "@id": "mrel:asg"
+            },
+            "associated_name": {
+              "@id": "mrel:asn"
+            },
+            "attributed_name": {
+              "@id": "mrel:att"
+            },
+            "auctioneer": {
+              "@id": "mrel:auc"
+            },
+            "author": {
+              "@id": "mrel:aut"
+            },
+            "author_in_quotations_or_text_abstracts": {
+              "@id": "mrel:aqt"
+            },
+            "author_of_afterword_colophon_etc": {
+              "@id": "mrel:aft"
+            },
+            "author_of_dialog": {
+              "@id": "mrel:aud"
+            },
+            "author_of_introduction_etc": {
+              "@id": "mrel:aui"
+            },
+            "autographer": {
+              "@id": "mrel:ato"
+            },
+            "bibliographic_antecedent": {
+              "@id": "mrel:ant"
+            },
+            "binder": {
+              "@id": "mrel:bnd"
+            },
+            "binding_designer": {
+              "@id": "mrel:bdd"
+            },
+            "blurb_writer": {
+              "@id": "mrel:blw"
+            },
+            "book_designer": {
+              "@id": "mrel:bkd"
+            },
+            "book_producer": {
+              "@id": "mrel:bkp"
+            },
+            "bookjacket_designer": {
+              "@id": "mrel:bjd"
+            },
+            "bookplate_designer": {
+              "@id": "mrel:bpd"
+            },
+            "bookseller": {
+              "@id": "mrel:bsl"
+            },
+            "braille_embosser": {
+              "@id": "mrel:brl"
+            },
+            "broadcaster": {
+              "@id": "mrel:brd"
+            },
+            "calligrapher": {
+              "@id": "mrel:cll"
+            },
+            "cartographer": {
+              "@id": "mrel:ctg"
+            },
+            "caster": {
+              "@id": "mrel:cas"
+            },
+            "censor": {
+              "@id": "mrel:cns"
+            },
+            "choreographer": {
+              "@id": "mrel:chr"
+            },
+            "cinematographer": {
+              "@id": "mrel:cng"
+            },
+            "client": {
+              "@id": "mrel:cli"
+            },
+            "collection_registrar": {
+              "@id": "mrel:cor"
+            },
+            "collector": {
+              "@id": "mrel:col"
+            },
+            "collotyper": {
+              "@id": "mrel:clt"
+            },
+            "colorist": {
+              "@id": "mrel:clr"
+            },
+            "commentator": {
+              "@id": "mrel:cmm"
+            },
+            "commentator_for_written_text": {
+              "@id": "mrel:cwt"
+            },
+            "compiler": {
+              "@id": "mrel:com"
+            },
+            "complainant": {
+              "@id": "mrel:cpl"
+            },
+            "complainant_appellant": {
+              "@id": "mrel:cpt"
+            },
+            "complainant_appellee": {
+              "@id": "mrel:cpe"
+            },
+            "composer": {
+              "@id": "mrel:cmp"
+            },
+            "compositor": {
+              "@id": "mrel:cmt"
+            },
+            "conceptor": {
+              "@id": "mrel:ccp"
+            },
+            "conductor": {
+              "@id": "mrel:cnd"
+            },
+            "conservator": {
+              "@id": "mrel:con"
+            },
+            "consultant": {
+              "@id": "mrel:csl"
+            },
+            "consultant_to_a_project": {
+              "@id": "mrel:csp"
+            },
+            "contestant": {
+              "@id": "mrel:cos"
+            },
+            "contestant_appellant": {
+              "@id": "mrel:cot"
+            },
+            "contestant_appellee": {
+              "@id": "mrel:coe"
+            },
+            "contestee": {
+              "@id": "mrel:cts"
+            },
+            "contestee_appellant": {
+              "@id": "mrel:ctt"
+            },
+            "contestee_appellee": {
+              "@id": "mrel:cte"
+            },
+            "contractor": {
+              "@id": "mrel:ctr"
+            },
+            "copyright_claimant": {
+              "@id": "mrel:cpc"
+            },
+            "copyright_holder": {
+              "@id": "mrel:cph"
+            },
+            "corrector": {
+              "@id": "mrel:crr"
+            },
+            "correspondent": {
+              "@id": "mrel:crp"
+            },
+            "costume_designer": {
+              "@id": "mrel:cst"
+            },
+            "court_governed": {
+              "@id": "mrel:cou"
+            },
+            "court_reporter": {
+              "@id": "mrel:crt"
+            },
+            "cover_designer": {
+              "@id": "mrel:cov"
+            },
+            "curator": {
+              "@id": "mrel:cur"
+            },
+            "dancer": {
+              "@id": "mrel:dnc"
+            },
+            "data_contributor": {
+              "@id": "mrel:dtc"
+            },
+            "data_manager": {
+              "@id": "mrel:dtm"
+            },
+            "dedicatee": {
+              "@id": "mrel:dte"
+            },
+            "dedicator": {
+              "@id": "mrel:dto"
+            },
+            "defendant": {
+              "@id": "mrel:dfd"
+            },
+            "defendant_appellant": {
+              "@id": "mrel:dft"
+            },
+            "defendant_appellee": {
+              "@id": "mrel:dfe"
+            },
+            "degree_granting_institution": {
+              "@id": "mrel:dgg"
+            },
+            "degree_supervisor": {
+              "@id": "mrel:dgs"
+            },
+            "delineator": {
+              "@id": "mrel:dln"
+            },
+            "depicted": {
+              "@id": "mrel:dpc"
+            },
+            "depositor": {
+              "@id": "mrel:dpt"
+            },
+            "designer": {
+              "@id": "mrel:dsr"
+            },
+            "director": {
+              "@id": "mrel:drt"
+            },
+            "dissertant": {
+              "@id": "mrel:dis"
+            },
+            "distribution_place": {
+              "@id": "mrel:dbp"
+            },
+            "distributor": {
+              "@id": "mrel:dst"
+            },
+            "donor": {
+              "@id": "mrel:dnr"
+            },
+            "draftsman": {
+              "@id": "mrel:drm"
+            },
+            "dubious_author": {
+              "@id": "mrel:dub"
+            },
+            "editor": {
+              "@id": "mrel:edt"
+            },
+            "editor_of_compilation": {
+              "@id": "mrel:edc"
+            },
+            "editor_of_moving_image_work": {
+              "@id": "mrel:edm"
+            },
+            "electrician": {
+              "@id": "mrel:elg"
+            },
+            "electrotyper": {
+              "@id": "mrel:elt"
+            },
+            "enacting_jurisdiction": {
+              "@id": "mrel:enj"
+            },
+            "engineer": {
+              "@id": "mrel:eng"
+            },
+            "engraver": {
+              "@id": "mrel:egr"
+            },
+            "etcher": {
+              "@id": "mrel:etr"
+            },
+            "event_place": {
+              "@id": "mrel:evp"
+            },
+            "expert": {
+              "@id": "mrel:exp"
+            },
+            "facsimilist": {
+              "@id": "mrel:fac"
+            },
+            "field_director": {
+              "@id": "mrel:fld"
+            },
+            "film_distributor": {
+              "@id": "mrel:fds"
+            },
+            "film_director": {
+              "@id": "mrel:fmd"
+            },
+            "film_editor": {
+              "@id": "mrel:flm"
+            },
+            "film_producer": {
+              "@id": "mrel:fmp"
+            },
+            "filmmaker": {
+              "@id": "mrel:fmk"
+            },
+            "first_party": {
+              "@id": "mrel:fpy"
+            },
+            "forger": {
+              "@id": "mrel:frg"
+            },
+            "former_owner": {
+              "@id": "mrel:fmo"
+            },
+            "funder": {
+              "@id": "mrel:fnd"
+            },
+            "geographic_information_specialist": {
+              "@id": "mrel:gis"
+            },
+            "honoree": {
+              "@id": "mrel:hnr"
+            },
+            "host": {
+              "@id": "mrel:hst"
+            },
+            "host_institution": {
+              "@id": "mrel:his"
+            },
+            "illuminator": {
+              "@id": "mrel:ilu"
+            },
+            "illustrator": {
+              "@id": "mrel:ill"
+            },
+            "inscriber": {
+              "@id": "mrel:ins"
+            },
+            "instrumentalist": {
+              "@id": "mrel:itr"
+            },
+            "interviewee": {
+              "@id": "mrel:ive"
+            },
+            "interviewer": {
+              "@id": "mrel:ivr"
+            },
+            "inventor": {
+              "@id": "mrel:inv"
+            },
+            "issuing_body": {
+              "@id": "mrel:isb"
+            },
+            "judge": {
+              "@id": "mrel:jud"
+            },
+            "jurisdiction_governed": {
+              "@id": "mrel:jug"
+            },
+            "laboratory": {
+              "@id": "mrel:lbr"
+            },
+            "laboratory_director": {
+              "@id": "mrel:ldr"
+            },
+            "landscape_architect": {
+              "@id": "mrel:lsa"
+            },
+            "lead": {
+              "@id": "mrel:led"
+            },
+            "lender": {
+              "@id": "mrel:len"
+            },
+            "libelant": {
+              "@id": "mrel:lil"
+            },
+            "libelant_appellant": {
+              "@id": "mrel:lit"
+            },
+            "libelant_appellee": {
+              "@id": "mrel:lie"
+            },
+            "libelee": {
+              "@id": "mrel:lel"
+            },
+            "libelee_appellant": {
+              "@id": "mrel:let"
+            },
+            "libelee_appellee": {
+              "@id": "mrel:lee"
+            },
+            "librettist": {
+              "@id": "mrel:lbt"
+            },
+            "licensee": {
+              "@id": "mrel:lse"
+            },
+            "licensor": {
+              "@id": "mrel:lso"
+            },
+            "lighting_designer": {
+              "@id": "mrel:lgd"
+            },
+            "lithographer": {
+              "@id": "mrel:ltg"
+            },
+            "lyricist": {
+              "@id": "mrel:lyr"
+            },
+            "manufacture_place": {
+              "@id": "mrel:mfp"
+            },
+            "manufacturer": {
+              "@id": "mrel:mfr"
+            },
+            "marbler": {
+              "@id": "mrel:mrb"
+            },
+            "markup_editor": {
+              "@id": "mrel:mrk"
+            },
+            "medium": {
+              "@id": "mrel:med"
+            },
+            "metadata_contact": {
+              "@id": "mrel:mdc"
+            },
+            "metal_engraver": {
+              "@id": "mrel:mte"
+            },
+            "minute_taker": {
+              "@id": "mrel:mtk"
+            },
+            "moderator": {
+              "@id": "mrel:mod"
+            },
+            "monitor": {
+              "@id": "mrel:mon"
+            },
+            "music_copyist": {
+              "@id": "mrel:mcp"
+            },
+            "musical_director": {
+              "@id": "mrel:msd"
+            },
+            "musician": {
+              "@id": "mrel:mus"
+            },
+            "narrator": {
+              "@id": "mrel:nrt"
+            },
+            "onscreen_presenter": {
+              "@id": "mrel:osp"
+            },
+            "opponent": {
+              "@id": "mrel:opn"
+            },
+            "organizer": {
+              "@id": "mrel:orm"
+            },
+            "originator": {
+              "@id": "mrel:org"
+            },
+            "other": {
+              "@id": "mrel:oth"
+            },
+            "owner": {
+              "@id": "mrel:own"
+            },
+            "panelist": {
+              "@id": "mrel:pan"
+            },
+            "papermaker": {
+              "@id": "mrel:ppm"
+            },
+            "patent_applicant": {
+              "@id": "mrel:pta"
+            },
+            "patent_holder": {
+              "@id": "mrel:pth"
+            },
+            "patron": {
+              "@id": "mrel:pat"
+            },
+            "performer": {
+              "@id": "mrel:prf"
+            },
+            "permitting_agency": {
+              "@id": "mrel:pma"
+            },
+            "photographer": {
+              "@id": "mrel:pht"
+            },
+            "plaintiff": {
+              "@id": "mrel:ptf"
+            },
+            "plaintiff_appellant": {
+              "@id": "mrel:ptt"
+            },
+            "plaintiff_appellee": {
+              "@id": "mrel:pte"
+            },
+            "platemaker": {
+              "@id": "mrel:plt"
+            },
+            "praeses": {
+              "@id": "mrel:pra"
+            },
+            "presenter": {
+              "@id": "mrel:pre"
+            },
+            "printer": {
+              "@id": "mrel:prt"
+            },
+            "printer_of_plates": {
+              "@id": "mrel:pop"
+            },
+            "printmaker": {
+              "@id": "mrel:prm"
+            },
+            "process_contact": {
+              "@id": "mrel:prc"
+            },
+            "producer": {
+              "@id": "mrel:pro"
+            },
+            "production_company": {
+              "@id": "mrel:prn"
+            },
+            "production_designer": {
+              "@id": "mrel:prs"
+            },
+            "production_manager": {
+              "@id": "mrel:pmn"
+            },
+            "production_personnel": {
+              "@id": "mrel:prd"
+            },
+            "production_place": {
+              "@id": "mrel:prp"
+            },
+            "programmer": {
+              "@id": "mrel:prg"
+            },
+            "project_director": {
+              "@id": "mrel:pdr"
+            },
+            "proofreader": {
+              "@id": "mrel:pfr"
+            },
+            "provider": {
+              "@id": "mrel:prv"
+            },
+            "publication_place": {
+              "@id": "mrel:pup"
+            },
+            "publishing_director": {
+              "@id": "mrel:pbd"
+            },
+            "puppeteer": {
+              "@id": "mrel:ppt"
+            },
+            "radio_director": {
+              "@id": "mrel:rdd"
+            },
+            "radio_producer": {
+              "@id": "mrel:rpc"
+            },
+            "recording_engineer": {
+              "@id": "mrel:rce"
+            },
+            "recordist": {
+              "@id": "mrel:rcd"
+            },
+            "redaktor": {
+              "@id": "mrel:red"
+            },
+            "renderer": {
+              "@id": "mrel:ren"
+            },
+            "reporter": {
+              "@id": "mrel:rpt"
+            },
+            "repository": {
+              "@id": "mrel:rps"
+            },
+            "research_team_head": {
+              "@id": "mrel:rth"
+            },
+            "research_team_member": {
+              "@id": "mrel:rtm"
+            },
+            "researcher": {
+              "@id": "mrel:res"
+            },
+            "respondent": {
+              "@id": "mrel:rsp"
+            },
+            "respondent_appellant": {
+              "@id": "mrel:rst"
+            },
+            "respondent_appellee": {
+              "@id": "mrel:rse"
+            },
+            "responsible_party": {
+              "@id": "mrel:rpy"
+            },
+            "restager": {
+              "@id": "mrel:rsg"
+            },
+            "restorationist": {
+              "@id": "mrel:rsr"
+            },
+            "reviewer": {
+              "@id": "mrel:rev"
+            },
+            "rubricator": {
+              "@id": "mrel:rbr"
+            },
+            "scenarist": {
+              "@id": "mrel:sce"
+            },
+            "scientific_advisor": {
+              "@id": "mrel:sad"
+            },
+            "screenwriter": {
+              "@id": "mrel:aus"
+            },
+            "scribe": {
+              "@id": "mrel:scr"
+            },
+            "sculptor": {
+              "@id": "mrel:scl"
+            },
+            "second_party": {
+              "@id": "mrel:spy"
+            },
+            "secretary": {
+              "@id": "mrel:sec"
+            },
+            "seller": {
+              "@id": "mrel:sll"
+            },
+            "set_designer": {
+              "@id": "mrel:std"
+            },
+            "setting": {
+              "@id": "mrel:stg"
+            },
+            "signer": {
+              "@id": "mrel:sgn"
+            },
+            "singer": {
+              "@id": "mrel:sng"
+            },
+            "sound_designer": {
+              "@id": "mrel:sds"
+            },
+            "speaker": {
+              "@id": "mrel:spk"
+            },
+            "sponsor": {
+              "@id": "mrel:spn"
+            },
+            "stage_director": {
+              "@id": "mrel:sgd"
+            },
+            "stage_manager": {
+              "@id": "mrel:stm"
+            },
+            "standards_body": {
+              "@id": "mrel:stn"
+            },
+            "stereotyper": {
+              "@id": "mrel:str"
+            },
+            "storyteller": {
+              "@id": "mrel:stl"
+            },
+            "supporting_host": {
+              "@id": "mrel:sht"
+            },
+            "surveyor": {
+              "@id": "mrel:srv"
+            },
+            "teacher": {
+              "@id": "mrel:tch"
+            },
+            "technical_director": {
+              "@id": "mrel:tcd"
+            },
+            "television_director": {
+              "@id": "mrel:tld"
+            },
+            "television_producer": {
+              "@id": "mrel:tlp"
+            },
+            "thesis_advisor": {
+              "@id": "mrel:ths"
+            },
+            "transcriber": {
+              "@id": "mrel:trc"
+            },
+            "translator": {
+              "@id": "mrel:trl"
+            },
+            "type_designer": {
+              "@id": "mrel:tyd"
+            },
+            "typographer": {
+              "@id": "mrel:tyg"
+            },
+            "university_place": {
+              "@id": "mrel:uvp"
+            },
+            "videographer": {
+              "@id": "mrel:vdg"
+            },
+            "voice_actor": {
+              "@id": "mrel:vac"
+            },
+            "witness": {
+              "@id": "mrel:wit"
+            },
+            "wood_engraver": {
+              "@id": "mrel:wde"
+            },
+            "woodcutter": {
+              "@id": "mrel:wdc"
+            },
+            "writer_of_accompanying_material": {
+              "@id": "mrel:wam"
+            },
+            "writer_of_added_commentary": {
+              "@id": "mrel:wac"
+            },
+            "writer_of_added_text": {
+              "@id": "mrel:wat"
+            },
+            "writer_of_added_lyrics": {
+              "@id": "mrel:wal"
+            },
+            "writer_of_supplementary_textual_content": {
+              "@id": "mrel:wst"
+            },
+            "writer_of_introduction": {
+              "@id": "mrel:win"
+            },
+            "writer_of_preface": {
+              "@id": "mrel:wpr"
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 18:32:42 GMT
+- request:
+    method: get
+    uri: http://bibdata.princeton.edu/context.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Date:
+      - Thu, 23 Feb 2017 18:32:42 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Location:
+      - https://bibdata.princeton.edu/context.json
+      Content-Length:
+      - '312'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>302 Found</title>
+        </head><body>
+        <h1>Found</h1>
+        <p>The document has moved <a href="https://bibdata.princeton.edu/context.json">here</a>.</p>
+        <hr>
+        <address>Apache/2.4.7 (Ubuntu) Server at bibdata.princeton.edu Port 80</address>
+        </body></html>
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 18:32:42 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/context.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/ld+json, application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Feb 2017 18:32:43 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Last-Modified:
+      - Thu, 23 Feb 2017 17:53:44 GMT
+      Etag:
+      - '"73ba-549364b4dba00"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '29626'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "@context": {
+            "id" : "@id",
+            "bf": "http://id.loc.gov/ontologies/bibframe/",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "dcterms": "http://purl.org/dc/terms/",
+            "mrel": "http://id.loc.gov/vocabulary/relators/",
+            "pulterms": "http://library.princeton.edu/terms/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+
+            "contributor": {"@id": "dc:contributor"},
+            "coverage": {"@id": "dc:coverage"},
+            "creator": {"@id": "dc:creator"},
+            "date": {"@id": "dc:date"},
+            "description": {"@id": "dc:description"},
+            "format": {"@id": "dc:format"},
+            "identifier": {"@id": "dc:identifier"},
+            "language": {"@id": "dc:language"},
+            "publisher": {"@id": "dc:publisher"},
+            "relation": {"@id": "dc:relation"},
+            "rights": {"@id": "dc:rights"},
+            "source": {"@id": "dc:source"},
+            "subject": {"@id": "dc:subject"},
+            "type": {"@id": "dc:type"},
+
+            "created": {"@id": "dcterms:created"},
+            "extent": {"@id": "dcterms:extent"},
+            "modified": {"@id": "dcterms:modified"},
+            "title": {"@id": "dcterms:title"},
+
+            "edition": {"@id": "bf:editionStatement"},
+            "call_number": {"@id": "pulterms:call_number"},
+
+            "abridger": {
+              "@id": "mrel:abr"
+            },
+            "actor": {
+              "@id": "mrel:act"
+            },
+            "adapter": {
+              "@id": "mrel:adp"
+            },
+            "addressee": {
+              "@id": "mrel:rcp"
+            },
+            "analyst": {
+              "@id": "mrel:anl"
+            },
+            "animator": {
+              "@id": "mrel:anm"
+            },
+            "annotator": {
+              "@id": "mrel:ann"
+            },
+            "appellant": {
+              "@id": "mrel:apl"
+            },
+            "appellee": {
+              "@id": "mrel:ape"
+            },
+            "applicant": {
+              "@id": "mrel:app"
+            },
+            "architect": {
+              "@id": "mrel:arc"
+            },
+            "arranger": {
+              "@id": "mrel:arr"
+            },
+            "art_copyist": {
+              "@id": "mrel:acp"
+            },
+            "art_director": {
+              "@id": "mrel:adi"
+            },
+            "artist": {
+              "@id": "mrel:art"
+            },
+            "artistic_director": {
+              "@id": "mrel:ard"
+            },
+            "assignee": {
+              "@id": "mrel:asg"
+            },
+            "associated_name": {
+              "@id": "mrel:asn"
+            },
+            "attributed_name": {
+              "@id": "mrel:att"
+            },
+            "auctioneer": {
+              "@id": "mrel:auc"
+            },
+            "author": {
+              "@id": "mrel:aut"
+            },
+            "author_in_quotations_or_text_abstracts": {
+              "@id": "mrel:aqt"
+            },
+            "author_of_afterword_colophon_etc": {
+              "@id": "mrel:aft"
+            },
+            "author_of_dialog": {
+              "@id": "mrel:aud"
+            },
+            "author_of_introduction_etc": {
+              "@id": "mrel:aui"
+            },
+            "autographer": {
+              "@id": "mrel:ato"
+            },
+            "bibliographic_antecedent": {
+              "@id": "mrel:ant"
+            },
+            "binder": {
+              "@id": "mrel:bnd"
+            },
+            "binding_designer": {
+              "@id": "mrel:bdd"
+            },
+            "blurb_writer": {
+              "@id": "mrel:blw"
+            },
+            "book_designer": {
+              "@id": "mrel:bkd"
+            },
+            "book_producer": {
+              "@id": "mrel:bkp"
+            },
+            "bookjacket_designer": {
+              "@id": "mrel:bjd"
+            },
+            "bookplate_designer": {
+              "@id": "mrel:bpd"
+            },
+            "bookseller": {
+              "@id": "mrel:bsl"
+            },
+            "braille_embosser": {
+              "@id": "mrel:brl"
+            },
+            "broadcaster": {
+              "@id": "mrel:brd"
+            },
+            "calligrapher": {
+              "@id": "mrel:cll"
+            },
+            "cartographer": {
+              "@id": "mrel:ctg"
+            },
+            "caster": {
+              "@id": "mrel:cas"
+            },
+            "censor": {
+              "@id": "mrel:cns"
+            },
+            "choreographer": {
+              "@id": "mrel:chr"
+            },
+            "cinematographer": {
+              "@id": "mrel:cng"
+            },
+            "client": {
+              "@id": "mrel:cli"
+            },
+            "collection_registrar": {
+              "@id": "mrel:cor"
+            },
+            "collector": {
+              "@id": "mrel:col"
+            },
+            "collotyper": {
+              "@id": "mrel:clt"
+            },
+            "colorist": {
+              "@id": "mrel:clr"
+            },
+            "commentator": {
+              "@id": "mrel:cmm"
+            },
+            "commentator_for_written_text": {
+              "@id": "mrel:cwt"
+            },
+            "compiler": {
+              "@id": "mrel:com"
+            },
+            "complainant": {
+              "@id": "mrel:cpl"
+            },
+            "complainant_appellant": {
+              "@id": "mrel:cpt"
+            },
+            "complainant_appellee": {
+              "@id": "mrel:cpe"
+            },
+            "composer": {
+              "@id": "mrel:cmp"
+            },
+            "compositor": {
+              "@id": "mrel:cmt"
+            },
+            "conceptor": {
+              "@id": "mrel:ccp"
+            },
+            "conductor": {
+              "@id": "mrel:cnd"
+            },
+            "conservator": {
+              "@id": "mrel:con"
+            },
+            "consultant": {
+              "@id": "mrel:csl"
+            },
+            "consultant_to_a_project": {
+              "@id": "mrel:csp"
+            },
+            "contestant": {
+              "@id": "mrel:cos"
+            },
+            "contestant_appellant": {
+              "@id": "mrel:cot"
+            },
+            "contestant_appellee": {
+              "@id": "mrel:coe"
+            },
+            "contestee": {
+              "@id": "mrel:cts"
+            },
+            "contestee_appellant": {
+              "@id": "mrel:ctt"
+            },
+            "contestee_appellee": {
+              "@id": "mrel:cte"
+            },
+            "contractor": {
+              "@id": "mrel:ctr"
+            },
+            "copyright_claimant": {
+              "@id": "mrel:cpc"
+            },
+            "copyright_holder": {
+              "@id": "mrel:cph"
+            },
+            "corrector": {
+              "@id": "mrel:crr"
+            },
+            "correspondent": {
+              "@id": "mrel:crp"
+            },
+            "costume_designer": {
+              "@id": "mrel:cst"
+            },
+            "court_governed": {
+              "@id": "mrel:cou"
+            },
+            "court_reporter": {
+              "@id": "mrel:crt"
+            },
+            "cover_designer": {
+              "@id": "mrel:cov"
+            },
+            "curator": {
+              "@id": "mrel:cur"
+            },
+            "dancer": {
+              "@id": "mrel:dnc"
+            },
+            "data_contributor": {
+              "@id": "mrel:dtc"
+            },
+            "data_manager": {
+              "@id": "mrel:dtm"
+            },
+            "dedicatee": {
+              "@id": "mrel:dte"
+            },
+            "dedicator": {
+              "@id": "mrel:dto"
+            },
+            "defendant": {
+              "@id": "mrel:dfd"
+            },
+            "defendant_appellant": {
+              "@id": "mrel:dft"
+            },
+            "defendant_appellee": {
+              "@id": "mrel:dfe"
+            },
+            "degree_granting_institution": {
+              "@id": "mrel:dgg"
+            },
+            "degree_supervisor": {
+              "@id": "mrel:dgs"
+            },
+            "delineator": {
+              "@id": "mrel:dln"
+            },
+            "depicted": {
+              "@id": "mrel:dpc"
+            },
+            "depositor": {
+              "@id": "mrel:dpt"
+            },
+            "designer": {
+              "@id": "mrel:dsr"
+            },
+            "director": {
+              "@id": "mrel:drt"
+            },
+            "dissertant": {
+              "@id": "mrel:dis"
+            },
+            "distribution_place": {
+              "@id": "mrel:dbp"
+            },
+            "distributor": {
+              "@id": "mrel:dst"
+            },
+            "donor": {
+              "@id": "mrel:dnr"
+            },
+            "draftsman": {
+              "@id": "mrel:drm"
+            },
+            "dubious_author": {
+              "@id": "mrel:dub"
+            },
+            "editor": {
+              "@id": "mrel:edt"
+            },
+            "editor_of_compilation": {
+              "@id": "mrel:edc"
+            },
+            "editor_of_moving_image_work": {
+              "@id": "mrel:edm"
+            },
+            "electrician": {
+              "@id": "mrel:elg"
+            },
+            "electrotyper": {
+              "@id": "mrel:elt"
+            },
+            "enacting_jurisdiction": {
+              "@id": "mrel:enj"
+            },
+            "engineer": {
+              "@id": "mrel:eng"
+            },
+            "engraver": {
+              "@id": "mrel:egr"
+            },
+            "etcher": {
+              "@id": "mrel:etr"
+            },
+            "event_place": {
+              "@id": "mrel:evp"
+            },
+            "expert": {
+              "@id": "mrel:exp"
+            },
+            "facsimilist": {
+              "@id": "mrel:fac"
+            },
+            "field_director": {
+              "@id": "mrel:fld"
+            },
+            "film_distributor": {
+              "@id": "mrel:fds"
+            },
+            "film_director": {
+              "@id": "mrel:fmd"
+            },
+            "film_editor": {
+              "@id": "mrel:flm"
+            },
+            "film_producer": {
+              "@id": "mrel:fmp"
+            },
+            "filmmaker": {
+              "@id": "mrel:fmk"
+            },
+            "first_party": {
+              "@id": "mrel:fpy"
+            },
+            "forger": {
+              "@id": "mrel:frg"
+            },
+            "former_owner": {
+              "@id": "mrel:fmo"
+            },
+            "funder": {
+              "@id": "mrel:fnd"
+            },
+            "geographic_information_specialist": {
+              "@id": "mrel:gis"
+            },
+            "honoree": {
+              "@id": "mrel:hnr"
+            },
+            "host": {
+              "@id": "mrel:hst"
+            },
+            "host_institution": {
+              "@id": "mrel:his"
+            },
+            "illuminator": {
+              "@id": "mrel:ilu"
+            },
+            "illustrator": {
+              "@id": "mrel:ill"
+            },
+            "inscriber": {
+              "@id": "mrel:ins"
+            },
+            "instrumentalist": {
+              "@id": "mrel:itr"
+            },
+            "interviewee": {
+              "@id": "mrel:ive"
+            },
+            "interviewer": {
+              "@id": "mrel:ivr"
+            },
+            "inventor": {
+              "@id": "mrel:inv"
+            },
+            "issuing_body": {
+              "@id": "mrel:isb"
+            },
+            "judge": {
+              "@id": "mrel:jud"
+            },
+            "jurisdiction_governed": {
+              "@id": "mrel:jug"
+            },
+            "laboratory": {
+              "@id": "mrel:lbr"
+            },
+            "laboratory_director": {
+              "@id": "mrel:ldr"
+            },
+            "landscape_architect": {
+              "@id": "mrel:lsa"
+            },
+            "lead": {
+              "@id": "mrel:led"
+            },
+            "lender": {
+              "@id": "mrel:len"
+            },
+            "libelant": {
+              "@id": "mrel:lil"
+            },
+            "libelant_appellant": {
+              "@id": "mrel:lit"
+            },
+            "libelant_appellee": {
+              "@id": "mrel:lie"
+            },
+            "libelee": {
+              "@id": "mrel:lel"
+            },
+            "libelee_appellant": {
+              "@id": "mrel:let"
+            },
+            "libelee_appellee": {
+              "@id": "mrel:lee"
+            },
+            "librettist": {
+              "@id": "mrel:lbt"
+            },
+            "licensee": {
+              "@id": "mrel:lse"
+            },
+            "licensor": {
+              "@id": "mrel:lso"
+            },
+            "lighting_designer": {
+              "@id": "mrel:lgd"
+            },
+            "lithographer": {
+              "@id": "mrel:ltg"
+            },
+            "lyricist": {
+              "@id": "mrel:lyr"
+            },
+            "manufacture_place": {
+              "@id": "mrel:mfp"
+            },
+            "manufacturer": {
+              "@id": "mrel:mfr"
+            },
+            "marbler": {
+              "@id": "mrel:mrb"
+            },
+            "markup_editor": {
+              "@id": "mrel:mrk"
+            },
+            "medium": {
+              "@id": "mrel:med"
+            },
+            "metadata_contact": {
+              "@id": "mrel:mdc"
+            },
+            "metal_engraver": {
+              "@id": "mrel:mte"
+            },
+            "minute_taker": {
+              "@id": "mrel:mtk"
+            },
+            "moderator": {
+              "@id": "mrel:mod"
+            },
+            "monitor": {
+              "@id": "mrel:mon"
+            },
+            "music_copyist": {
+              "@id": "mrel:mcp"
+            },
+            "musical_director": {
+              "@id": "mrel:msd"
+            },
+            "musician": {
+              "@id": "mrel:mus"
+            },
+            "narrator": {
+              "@id": "mrel:nrt"
+            },
+            "onscreen_presenter": {
+              "@id": "mrel:osp"
+            },
+            "opponent": {
+              "@id": "mrel:opn"
+            },
+            "organizer": {
+              "@id": "mrel:orm"
+            },
+            "originator": {
+              "@id": "mrel:org"
+            },
+            "other": {
+              "@id": "mrel:oth"
+            },
+            "owner": {
+              "@id": "mrel:own"
+            },
+            "panelist": {
+              "@id": "mrel:pan"
+            },
+            "papermaker": {
+              "@id": "mrel:ppm"
+            },
+            "patent_applicant": {
+              "@id": "mrel:pta"
+            },
+            "patent_holder": {
+              "@id": "mrel:pth"
+            },
+            "patron": {
+              "@id": "mrel:pat"
+            },
+            "performer": {
+              "@id": "mrel:prf"
+            },
+            "permitting_agency": {
+              "@id": "mrel:pma"
+            },
+            "photographer": {
+              "@id": "mrel:pht"
+            },
+            "plaintiff": {
+              "@id": "mrel:ptf"
+            },
+            "plaintiff_appellant": {
+              "@id": "mrel:ptt"
+            },
+            "plaintiff_appellee": {
+              "@id": "mrel:pte"
+            },
+            "platemaker": {
+              "@id": "mrel:plt"
+            },
+            "praeses": {
+              "@id": "mrel:pra"
+            },
+            "presenter": {
+              "@id": "mrel:pre"
+            },
+            "printer": {
+              "@id": "mrel:prt"
+            },
+            "printer_of_plates": {
+              "@id": "mrel:pop"
+            },
+            "printmaker": {
+              "@id": "mrel:prm"
+            },
+            "process_contact": {
+              "@id": "mrel:prc"
+            },
+            "producer": {
+              "@id": "mrel:pro"
+            },
+            "production_company": {
+              "@id": "mrel:prn"
+            },
+            "production_designer": {
+              "@id": "mrel:prs"
+            },
+            "production_manager": {
+              "@id": "mrel:pmn"
+            },
+            "production_personnel": {
+              "@id": "mrel:prd"
+            },
+            "production_place": {
+              "@id": "mrel:prp"
+            },
+            "programmer": {
+              "@id": "mrel:prg"
+            },
+            "project_director": {
+              "@id": "mrel:pdr"
+            },
+            "proofreader": {
+              "@id": "mrel:pfr"
+            },
+            "provider": {
+              "@id": "mrel:prv"
+            },
+            "publication_place": {
+              "@id": "mrel:pup"
+            },
+            "publishing_director": {
+              "@id": "mrel:pbd"
+            },
+            "puppeteer": {
+              "@id": "mrel:ppt"
+            },
+            "radio_director": {
+              "@id": "mrel:rdd"
+            },
+            "radio_producer": {
+              "@id": "mrel:rpc"
+            },
+            "recording_engineer": {
+              "@id": "mrel:rce"
+            },
+            "recordist": {
+              "@id": "mrel:rcd"
+            },
+            "redaktor": {
+              "@id": "mrel:red"
+            },
+            "renderer": {
+              "@id": "mrel:ren"
+            },
+            "reporter": {
+              "@id": "mrel:rpt"
+            },
+            "repository": {
+              "@id": "mrel:rps"
+            },
+            "research_team_head": {
+              "@id": "mrel:rth"
+            },
+            "research_team_member": {
+              "@id": "mrel:rtm"
+            },
+            "researcher": {
+              "@id": "mrel:res"
+            },
+            "respondent": {
+              "@id": "mrel:rsp"
+            },
+            "respondent_appellant": {
+              "@id": "mrel:rst"
+            },
+            "respondent_appellee": {
+              "@id": "mrel:rse"
+            },
+            "responsible_party": {
+              "@id": "mrel:rpy"
+            },
+            "restager": {
+              "@id": "mrel:rsg"
+            },
+            "restorationist": {
+              "@id": "mrel:rsr"
+            },
+            "reviewer": {
+              "@id": "mrel:rev"
+            },
+            "rubricator": {
+              "@id": "mrel:rbr"
+            },
+            "scenarist": {
+              "@id": "mrel:sce"
+            },
+            "scientific_advisor": {
+              "@id": "mrel:sad"
+            },
+            "screenwriter": {
+              "@id": "mrel:aus"
+            },
+            "scribe": {
+              "@id": "mrel:scr"
+            },
+            "sculptor": {
+              "@id": "mrel:scl"
+            },
+            "second_party": {
+              "@id": "mrel:spy"
+            },
+            "secretary": {
+              "@id": "mrel:sec"
+            },
+            "seller": {
+              "@id": "mrel:sll"
+            },
+            "set_designer": {
+              "@id": "mrel:std"
+            },
+            "setting": {
+              "@id": "mrel:stg"
+            },
+            "signer": {
+              "@id": "mrel:sgn"
+            },
+            "singer": {
+              "@id": "mrel:sng"
+            },
+            "sound_designer": {
+              "@id": "mrel:sds"
+            },
+            "speaker": {
+              "@id": "mrel:spk"
+            },
+            "sponsor": {
+              "@id": "mrel:spn"
+            },
+            "stage_director": {
+              "@id": "mrel:sgd"
+            },
+            "stage_manager": {
+              "@id": "mrel:stm"
+            },
+            "standards_body": {
+              "@id": "mrel:stn"
+            },
+            "stereotyper": {
+              "@id": "mrel:str"
+            },
+            "storyteller": {
+              "@id": "mrel:stl"
+            },
+            "supporting_host": {
+              "@id": "mrel:sht"
+            },
+            "surveyor": {
+              "@id": "mrel:srv"
+            },
+            "teacher": {
+              "@id": "mrel:tch"
+            },
+            "technical_director": {
+              "@id": "mrel:tcd"
+            },
+            "television_director": {
+              "@id": "mrel:tld"
+            },
+            "television_producer": {
+              "@id": "mrel:tlp"
+            },
+            "thesis_advisor": {
+              "@id": "mrel:ths"
+            },
+            "transcriber": {
+              "@id": "mrel:trc"
+            },
+            "translator": {
+              "@id": "mrel:trl"
+            },
+            "type_designer": {
+              "@id": "mrel:tyd"
+            },
+            "typographer": {
+              "@id": "mrel:tyg"
+            },
+            "university_place": {
+              "@id": "mrel:uvp"
+            },
+            "videographer": {
+              "@id": "mrel:vdg"
+            },
+            "voice_actor": {
+              "@id": "mrel:vac"
+            },
+            "witness": {
+              "@id": "mrel:wit"
+            },
+            "wood_engraver": {
+              "@id": "mrel:wde"
+            },
+            "woodcutter": {
+              "@id": "mrel:wdc"
+            },
+            "writer_of_accompanying_material": {
+              "@id": "mrel:wam"
+            },
+            "writer_of_added_commentary": {
+              "@id": "mrel:wac"
+            },
+            "writer_of_added_text": {
+              "@id": "mrel:wat"
+            },
+            "writer_of_added_lyrics": {
+              "@id": "mrel:wal"
+            },
+            "writer_of_supplementary_textual_content": {
+              "@id": "mrel:wst"
+            },
+            "writer_of_introduction": {
+              "@id": "mrel:win"
+            },
+            "writer_of_preface": {
+              "@id": "mrel:wpr"
+            },
+            "abridger": {
+              "@id": "mrel:abr"
+            },
+            "actor": {
+              "@id": "mrel:act"
+            },
+            "adapter": {
+              "@id": "mrel:adp"
+            },
+            "addressee": {
+              "@id": "mrel:rcp"
+            },
+            "analyst": {
+              "@id": "mrel:anl"
+            },
+            "animator": {
+              "@id": "mrel:anm"
+            },
+            "annotator": {
+              "@id": "mrel:ann"
+            },
+            "appellant": {
+              "@id": "mrel:apl"
+            },
+            "appellee": {
+              "@id": "mrel:ape"
+            },
+            "applicant": {
+              "@id": "mrel:app"
+            },
+            "architect": {
+              "@id": "mrel:arc"
+            },
+            "arranger": {
+              "@id": "mrel:arr"
+            },
+            "art_copyist": {
+              "@id": "mrel:acp"
+            },
+            "art_director": {
+              "@id": "mrel:adi"
+            },
+            "artist": {
+              "@id": "mrel:art"
+            },
+            "artistic_director": {
+              "@id": "mrel:ard"
+            },
+            "assignee": {
+              "@id": "mrel:asg"
+            },
+            "associated_name": {
+              "@id": "mrel:asn"
+            },
+            "attributed_name": {
+              "@id": "mrel:att"
+            },
+            "auctioneer": {
+              "@id": "mrel:auc"
+            },
+            "author": {
+              "@id": "mrel:aut"
+            },
+            "author_in_quotations_or_text_abstracts": {
+              "@id": "mrel:aqt"
+            },
+            "author_of_afterword_colophon_etc": {
+              "@id": "mrel:aft"
+            },
+            "author_of_dialog": {
+              "@id": "mrel:aud"
+            },
+            "author_of_introduction_etc": {
+              "@id": "mrel:aui"
+            },
+            "autographer": {
+              "@id": "mrel:ato"
+            },
+            "bibliographic_antecedent": {
+              "@id": "mrel:ant"
+            },
+            "binder": {
+              "@id": "mrel:bnd"
+            },
+            "binding_designer": {
+              "@id": "mrel:bdd"
+            },
+            "blurb_writer": {
+              "@id": "mrel:blw"
+            },
+            "book_designer": {
+              "@id": "mrel:bkd"
+            },
+            "book_producer": {
+              "@id": "mrel:bkp"
+            },
+            "bookjacket_designer": {
+              "@id": "mrel:bjd"
+            },
+            "bookplate_designer": {
+              "@id": "mrel:bpd"
+            },
+            "bookseller": {
+              "@id": "mrel:bsl"
+            },
+            "braille_embosser": {
+              "@id": "mrel:brl"
+            },
+            "broadcaster": {
+              "@id": "mrel:brd"
+            },
+            "calligrapher": {
+              "@id": "mrel:cll"
+            },
+            "cartographer": {
+              "@id": "mrel:ctg"
+            },
+            "caster": {
+              "@id": "mrel:cas"
+            },
+            "censor": {
+              "@id": "mrel:cns"
+            },
+            "choreographer": {
+              "@id": "mrel:chr"
+            },
+            "cinematographer": {
+              "@id": "mrel:cng"
+            },
+            "client": {
+              "@id": "mrel:cli"
+            },
+            "collection_registrar": {
+              "@id": "mrel:cor"
+            },
+            "collector": {
+              "@id": "mrel:col"
+            },
+            "collotyper": {
+              "@id": "mrel:clt"
+            },
+            "colorist": {
+              "@id": "mrel:clr"
+            },
+            "commentator": {
+              "@id": "mrel:cmm"
+            },
+            "commentator_for_written_text": {
+              "@id": "mrel:cwt"
+            },
+            "compiler": {
+              "@id": "mrel:com"
+            },
+            "complainant": {
+              "@id": "mrel:cpl"
+            },
+            "complainant_appellant": {
+              "@id": "mrel:cpt"
+            },
+            "complainant_appellee": {
+              "@id": "mrel:cpe"
+            },
+            "composer": {
+              "@id": "mrel:cmp"
+            },
+            "compositor": {
+              "@id": "mrel:cmt"
+            },
+            "conceptor": {
+              "@id": "mrel:ccp"
+            },
+            "conductor": {
+              "@id": "mrel:cnd"
+            },
+            "conservator": {
+              "@id": "mrel:con"
+            },
+            "consultant": {
+              "@id": "mrel:csl"
+            },
+            "consultant_to_a_project": {
+              "@id": "mrel:csp"
+            },
+            "contestant": {
+              "@id": "mrel:cos"
+            },
+            "contestant_appellant": {
+              "@id": "mrel:cot"
+            },
+            "contestant_appellee": {
+              "@id": "mrel:coe"
+            },
+            "contestee": {
+              "@id": "mrel:cts"
+            },
+            "contestee_appellant": {
+              "@id": "mrel:ctt"
+            },
+            "contestee_appellee": {
+              "@id": "mrel:cte"
+            },
+            "contractor": {
+              "@id": "mrel:ctr"
+            },
+            "copyright_claimant": {
+              "@id": "mrel:cpc"
+            },
+            "copyright_holder": {
+              "@id": "mrel:cph"
+            },
+            "corrector": {
+              "@id": "mrel:crr"
+            },
+            "correspondent": {
+              "@id": "mrel:crp"
+            },
+            "costume_designer": {
+              "@id": "mrel:cst"
+            },
+            "court_governed": {
+              "@id": "mrel:cou"
+            },
+            "court_reporter": {
+              "@id": "mrel:crt"
+            },
+            "cover_designer": {
+              "@id": "mrel:cov"
+            },
+            "curator": {
+              "@id": "mrel:cur"
+            },
+            "dancer": {
+              "@id": "mrel:dnc"
+            },
+            "data_contributor": {
+              "@id": "mrel:dtc"
+            },
+            "data_manager": {
+              "@id": "mrel:dtm"
+            },
+            "dedicatee": {
+              "@id": "mrel:dte"
+            },
+            "dedicator": {
+              "@id": "mrel:dto"
+            },
+            "defendant": {
+              "@id": "mrel:dfd"
+            },
+            "defendant_appellant": {
+              "@id": "mrel:dft"
+            },
+            "defendant_appellee": {
+              "@id": "mrel:dfe"
+            },
+            "degree_granting_institution": {
+              "@id": "mrel:dgg"
+            },
+            "degree_supervisor": {
+              "@id": "mrel:dgs"
+            },
+            "delineator": {
+              "@id": "mrel:dln"
+            },
+            "depicted": {
+              "@id": "mrel:dpc"
+            },
+            "depositor": {
+              "@id": "mrel:dpt"
+            },
+            "designer": {
+              "@id": "mrel:dsr"
+            },
+            "director": {
+              "@id": "mrel:drt"
+            },
+            "dissertant": {
+              "@id": "mrel:dis"
+            },
+            "distribution_place": {
+              "@id": "mrel:dbp"
+            },
+            "distributor": {
+              "@id": "mrel:dst"
+            },
+            "donor": {
+              "@id": "mrel:dnr"
+            },
+            "draftsman": {
+              "@id": "mrel:drm"
+            },
+            "dubious_author": {
+              "@id": "mrel:dub"
+            },
+            "editor": {
+              "@id": "mrel:edt"
+            },
+            "editor_of_compilation": {
+              "@id": "mrel:edc"
+            },
+            "editor_of_moving_image_work": {
+              "@id": "mrel:edm"
+            },
+            "electrician": {
+              "@id": "mrel:elg"
+            },
+            "electrotyper": {
+              "@id": "mrel:elt"
+            },
+            "enacting_jurisdiction": {
+              "@id": "mrel:enj"
+            },
+            "engineer": {
+              "@id": "mrel:eng"
+            },
+            "engraver": {
+              "@id": "mrel:egr"
+            },
+            "etcher": {
+              "@id": "mrel:etr"
+            },
+            "event_place": {
+              "@id": "mrel:evp"
+            },
+            "expert": {
+              "@id": "mrel:exp"
+            },
+            "facsimilist": {
+              "@id": "mrel:fac"
+            },
+            "field_director": {
+              "@id": "mrel:fld"
+            },
+            "film_distributor": {
+              "@id": "mrel:fds"
+            },
+            "film_director": {
+              "@id": "mrel:fmd"
+            },
+            "film_editor": {
+              "@id": "mrel:flm"
+            },
+            "film_producer": {
+              "@id": "mrel:fmp"
+            },
+            "filmmaker": {
+              "@id": "mrel:fmk"
+            },
+            "first_party": {
+              "@id": "mrel:fpy"
+            },
+            "forger": {
+              "@id": "mrel:frg"
+            },
+            "former_owner": {
+              "@id": "mrel:fmo"
+            },
+            "funder": {
+              "@id": "mrel:fnd"
+            },
+            "geographic_information_specialist": {
+              "@id": "mrel:gis"
+            },
+            "honoree": {
+              "@id": "mrel:hnr"
+            },
+            "host": {
+              "@id": "mrel:hst"
+            },
+            "host_institution": {
+              "@id": "mrel:his"
+            },
+            "illuminator": {
+              "@id": "mrel:ilu"
+            },
+            "illustrator": {
+              "@id": "mrel:ill"
+            },
+            "inscriber": {
+              "@id": "mrel:ins"
+            },
+            "instrumentalist": {
+              "@id": "mrel:itr"
+            },
+            "interviewee": {
+              "@id": "mrel:ive"
+            },
+            "interviewer": {
+              "@id": "mrel:ivr"
+            },
+            "inventor": {
+              "@id": "mrel:inv"
+            },
+            "issuing_body": {
+              "@id": "mrel:isb"
+            },
+            "judge": {
+              "@id": "mrel:jud"
+            },
+            "jurisdiction_governed": {
+              "@id": "mrel:jug"
+            },
+            "laboratory": {
+              "@id": "mrel:lbr"
+            },
+            "laboratory_director": {
+              "@id": "mrel:ldr"
+            },
+            "landscape_architect": {
+              "@id": "mrel:lsa"
+            },
+            "lead": {
+              "@id": "mrel:led"
+            },
+            "lender": {
+              "@id": "mrel:len"
+            },
+            "libelant": {
+              "@id": "mrel:lil"
+            },
+            "libelant_appellant": {
+              "@id": "mrel:lit"
+            },
+            "libelant_appellee": {
+              "@id": "mrel:lie"
+            },
+            "libelee": {
+              "@id": "mrel:lel"
+            },
+            "libelee_appellant": {
+              "@id": "mrel:let"
+            },
+            "libelee_appellee": {
+              "@id": "mrel:lee"
+            },
+            "librettist": {
+              "@id": "mrel:lbt"
+            },
+            "licensee": {
+              "@id": "mrel:lse"
+            },
+            "licensor": {
+              "@id": "mrel:lso"
+            },
+            "lighting_designer": {
+              "@id": "mrel:lgd"
+            },
+            "lithographer": {
+              "@id": "mrel:ltg"
+            },
+            "lyricist": {
+              "@id": "mrel:lyr"
+            },
+            "manufacture_place": {
+              "@id": "mrel:mfp"
+            },
+            "manufacturer": {
+              "@id": "mrel:mfr"
+            },
+            "marbler": {
+              "@id": "mrel:mrb"
+            },
+            "markup_editor": {
+              "@id": "mrel:mrk"
+            },
+            "medium": {
+              "@id": "mrel:med"
+            },
+            "metadata_contact": {
+              "@id": "mrel:mdc"
+            },
+            "metal_engraver": {
+              "@id": "mrel:mte"
+            },
+            "minute_taker": {
+              "@id": "mrel:mtk"
+            },
+            "moderator": {
+              "@id": "mrel:mod"
+            },
+            "monitor": {
+              "@id": "mrel:mon"
+            },
+            "music_copyist": {
+              "@id": "mrel:mcp"
+            },
+            "musical_director": {
+              "@id": "mrel:msd"
+            },
+            "musician": {
+              "@id": "mrel:mus"
+            },
+            "narrator": {
+              "@id": "mrel:nrt"
+            },
+            "onscreen_presenter": {
+              "@id": "mrel:osp"
+            },
+            "opponent": {
+              "@id": "mrel:opn"
+            },
+            "organizer": {
+              "@id": "mrel:orm"
+            },
+            "originator": {
+              "@id": "mrel:org"
+            },
+            "other": {
+              "@id": "mrel:oth"
+            },
+            "owner": {
+              "@id": "mrel:own"
+            },
+            "panelist": {
+              "@id": "mrel:pan"
+            },
+            "papermaker": {
+              "@id": "mrel:ppm"
+            },
+            "patent_applicant": {
+              "@id": "mrel:pta"
+            },
+            "patent_holder": {
+              "@id": "mrel:pth"
+            },
+            "patron": {
+              "@id": "mrel:pat"
+            },
+            "performer": {
+              "@id": "mrel:prf"
+            },
+            "permitting_agency": {
+              "@id": "mrel:pma"
+            },
+            "photographer": {
+              "@id": "mrel:pht"
+            },
+            "plaintiff": {
+              "@id": "mrel:ptf"
+            },
+            "plaintiff_appellant": {
+              "@id": "mrel:ptt"
+            },
+            "plaintiff_appellee": {
+              "@id": "mrel:pte"
+            },
+            "platemaker": {
+              "@id": "mrel:plt"
+            },
+            "praeses": {
+              "@id": "mrel:pra"
+            },
+            "presenter": {
+              "@id": "mrel:pre"
+            },
+            "printer": {
+              "@id": "mrel:prt"
+            },
+            "printer_of_plates": {
+              "@id": "mrel:pop"
+            },
+            "printmaker": {
+              "@id": "mrel:prm"
+            },
+            "process_contact": {
+              "@id": "mrel:prc"
+            },
+            "producer": {
+              "@id": "mrel:pro"
+            },
+            "production_company": {
+              "@id": "mrel:prn"
+            },
+            "production_designer": {
+              "@id": "mrel:prs"
+            },
+            "production_manager": {
+              "@id": "mrel:pmn"
+            },
+            "production_personnel": {
+              "@id": "mrel:prd"
+            },
+            "production_place": {
+              "@id": "mrel:prp"
+            },
+            "programmer": {
+              "@id": "mrel:prg"
+            },
+            "project_director": {
+              "@id": "mrel:pdr"
+            },
+            "proofreader": {
+              "@id": "mrel:pfr"
+            },
+            "provider": {
+              "@id": "mrel:prv"
+            },
+            "publication_place": {
+              "@id": "mrel:pup"
+            },
+            "publishing_director": {
+              "@id": "mrel:pbd"
+            },
+            "puppeteer": {
+              "@id": "mrel:ppt"
+            },
+            "radio_director": {
+              "@id": "mrel:rdd"
+            },
+            "radio_producer": {
+              "@id": "mrel:rpc"
+            },
+            "recording_engineer": {
+              "@id": "mrel:rce"
+            },
+            "recordist": {
+              "@id": "mrel:rcd"
+            },
+            "redaktor": {
+              "@id": "mrel:red"
+            },
+            "renderer": {
+              "@id": "mrel:ren"
+            },
+            "reporter": {
+              "@id": "mrel:rpt"
+            },
+            "repository": {
+              "@id": "mrel:rps"
+            },
+            "research_team_head": {
+              "@id": "mrel:rth"
+            },
+            "research_team_member": {
+              "@id": "mrel:rtm"
+            },
+            "researcher": {
+              "@id": "mrel:res"
+            },
+            "respondent": {
+              "@id": "mrel:rsp"
+            },
+            "respondent_appellant": {
+              "@id": "mrel:rst"
+            },
+            "respondent_appellee": {
+              "@id": "mrel:rse"
+            },
+            "responsible_party": {
+              "@id": "mrel:rpy"
+            },
+            "restager": {
+              "@id": "mrel:rsg"
+            },
+            "restorationist": {
+              "@id": "mrel:rsr"
+            },
+            "reviewer": {
+              "@id": "mrel:rev"
+            },
+            "rubricator": {
+              "@id": "mrel:rbr"
+            },
+            "scenarist": {
+              "@id": "mrel:sce"
+            },
+            "scientific_advisor": {
+              "@id": "mrel:sad"
+            },
+            "screenwriter": {
+              "@id": "mrel:aus"
+            },
+            "scribe": {
+              "@id": "mrel:scr"
+            },
+            "sculptor": {
+              "@id": "mrel:scl"
+            },
+            "second_party": {
+              "@id": "mrel:spy"
+            },
+            "secretary": {
+              "@id": "mrel:sec"
+            },
+            "seller": {
+              "@id": "mrel:sll"
+            },
+            "set_designer": {
+              "@id": "mrel:std"
+            },
+            "setting": {
+              "@id": "mrel:stg"
+            },
+            "signer": {
+              "@id": "mrel:sgn"
+            },
+            "singer": {
+              "@id": "mrel:sng"
+            },
+            "sound_designer": {
+              "@id": "mrel:sds"
+            },
+            "speaker": {
+              "@id": "mrel:spk"
+            },
+            "sponsor": {
+              "@id": "mrel:spn"
+            },
+            "stage_director": {
+              "@id": "mrel:sgd"
+            },
+            "stage_manager": {
+              "@id": "mrel:stm"
+            },
+            "standards_body": {
+              "@id": "mrel:stn"
+            },
+            "stereotyper": {
+              "@id": "mrel:str"
+            },
+            "storyteller": {
+              "@id": "mrel:stl"
+            },
+            "supporting_host": {
+              "@id": "mrel:sht"
+            },
+            "surveyor": {
+              "@id": "mrel:srv"
+            },
+            "teacher": {
+              "@id": "mrel:tch"
+            },
+            "technical_director": {
+              "@id": "mrel:tcd"
+            },
+            "television_director": {
+              "@id": "mrel:tld"
+            },
+            "television_producer": {
+              "@id": "mrel:tlp"
+            },
+            "thesis_advisor": {
+              "@id": "mrel:ths"
+            },
+            "transcriber": {
+              "@id": "mrel:trc"
+            },
+            "translator": {
+              "@id": "mrel:trl"
+            },
+            "type_designer": {
+              "@id": "mrel:tyd"
+            },
+            "typographer": {
+              "@id": "mrel:tyg"
+            },
+            "university_place": {
+              "@id": "mrel:uvp"
+            },
+            "videographer": {
+              "@id": "mrel:vdg"
+            },
+            "voice_actor": {
+              "@id": "mrel:vac"
+            },
+            "witness": {
+              "@id": "mrel:wit"
+            },
+            "wood_engraver": {
+              "@id": "mrel:wde"
+            },
+            "woodcutter": {
+              "@id": "mrel:wdc"
+            },
+            "writer_of_accompanying_material": {
+              "@id": "mrel:wam"
+            },
+            "writer_of_added_commentary": {
+              "@id": "mrel:wac"
+            },
+            "writer_of_added_text": {
+              "@id": "mrel:wat"
+            },
+            "writer_of_added_lyrics": {
+              "@id": "mrel:wal"
+            },
+            "writer_of_supplementary_textual_content": {
+              "@id": "mrel:wst"
+            },
+            "writer_of_introduction": {
+              "@id": "mrel:win"
+            },
+            "writer_of_preface": {
+              "@id": "mrel:wpr"
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 23 Feb 2017 18:32:43 GMT
+recorded_with: VCR 2.9.3

--- a/spec/factories/image_works.rb
+++ b/spec/factories/image_works.rb
@@ -1,0 +1,30 @@
+FactoryGirl.define do
+  factory :image_work do
+    title ["Test title"]
+    rights_statement "http://rightsstatements.org/vocab/NKC/1.0/"
+    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    state Vocab::FedoraResourceStatus.active
+
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    end
+
+    factory :complete_image_work do
+      after(:create) do |work, evaluator|
+        FactoryGirl.create(:complete_sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+        work.save
+      end
+    end
+
+    factory :pending_image_work do
+      after(:create) do |work, evaluator|
+        FactoryGirl.create(:pending_sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+        work.save
+      end
+    end
+  end
+end

--- a/spec/models/image_work_spec.rb
+++ b/spec/models/image_work_spec.rb
@@ -1,7 +1,41 @@
-# Generated via
-#  `rails generate geo_concerns:install`
 require 'rails_helper'
 
 describe ImageWork do
-  it { is_expected.to be_kind_of(GeoWorks::ImageWorkBehavior) }
+  let(:image_work) { FactoryGirl.build(:image_work, rights_statement: 'http://rightsstatements.org/vocab/NKC/1.0/') }
+  subject { image_work }
+
+  describe 'apply_remote_metadata' do
+    context 'when source_metadata_identifier is not set' do
+      before { subject.source_metadata_identifier = nil }
+      it 'does nothing' do
+        original_attributes = subject.attributes
+        expect(subject.send(:remote_metadata_factory)).to_not receive(:new)
+        subject.apply_remote_metadata
+        expect(subject.attributes).to eq(original_attributes)
+      end
+    end
+
+    context 'With a Voyager ID', vcr: { cassette_name: "bibdata-maps" } do
+      before do
+        subject.source_metadata_identifier = '9284317'
+      end
+
+      it 'Extracts Voyager Metadata' do
+        subject.apply_remote_metadata
+        expect(subject.title.first.to_s).to eq('Netherlands, Nieuwe Waterweg and Europoort : Hoek Van Holland to Vlaardingen')
+        expect(subject.resource.get_values(:title, literal: true)).to eq([RDF::Literal.new('Netherlands, Nieuwe Waterweg and Europoort : Hoek Van Holland to Vlaardingen', language: :eng)])
+        expect(subject.creator).to eq(['United States. Defense Mapping Agency. Hydrographic/Topographic Center'])
+        expect(subject.date_created).to eq(['1994-01-01T00:00:00Z'])
+        expect(subject.publisher).to eq(['Bethesda, Md. : Defense Mapping Agency, Hydrographic/Topographic Center, 1994.'])
+        expect(subject.coverage).to eq('northlimit=52.024167; eastlimit=004.341667; southlimit=51.920000; westlimit=003.966667; units=degrees; projection=EPSG:4326')
+      end
+
+      it 'Saves a record with extacted Voyager metadata' do
+        subject.apply_remote_metadata
+        subject.save
+        expect { subject.save }.to_not raise_error
+        expect(subject.id).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/services/plum_derivative_service_spec.rb
+++ b/spec/services/plum_derivative_service_spec.rb
@@ -27,4 +27,22 @@ RSpec.describe PlumDerivativesService do
       end
     end
   end
+
+  describe "#recipe" do
+    context "with a non-map tiff" do
+      it "uses the default recipe" do
+        expect(subject.send(:recipe)).to eq(:default)
+      end
+    end
+
+    context "with a map tiff" do
+      before do
+        allow(file_set).to receive(:geo_mime_type).and_return "image/tiff"
+      end
+
+      it "uses the geo recipe" do
+        expect(subject.send(:recipe)).to eq(:geo)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Allows ImageWorks to pull metadata from in from bibdata and to display image derivatives with the Universal Viewer. Closes #1004 