### PR TITLE
Replace get_json method with json method in holding location authority

### DIFF
--- a/app/authorities/holding_location_authority.rb
+++ b/app/authorities/holding_location_authority.rb
@@ -2,7 +2,7 @@ class HoldingLocationAuthority
   include Qa::Authorities::WebServiceBase
 
   def all
-    get_json(url).each { |loc| loc['id'] = loc['url'].sub(/\.json$/, '') }
+    json(url).each { |loc| loc['id'] = loc['url'].sub(/\.json$/, '') }
   end
 
   def find(id)

--- a/spec/authorities/holding_location_authority_spec.rb
+++ b/spec/authorities/holding_location_authority_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe HoldingLocationAuthority do
   }
 
   before do
-    allow(subject).to receive(:get_json).and_return(JSON.parse(json))
+    allow(subject).to receive(:json).and_return(JSON.parse(json))
   end
 
   context "with data" do


### PR DESCRIPTION
Replace get_json method with json method in holding location authority to remove QA deprecation warning.

https://github.com/projecthydra-labs/questioning_authority/blob/4cfef296f8ebce5e9c11a350756732c3a8ac3b27/lib/qa/authorities/web_service_base.rb#L24