### PR TITLE
Initialize datadog in staging or production only

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,10 +1,12 @@
 require 'net/http'
 require 'redis'
-require 'ddtrace'
 
-Rails.configuration.datadog_trace = {
-  auto_instrument: true,
-  auto_instrument_redis: true,
-  default_service: "Plum (#{Rails.env})"
-}
-Datadog::Monkey.patch_all
+if Rails.env.staging? || Rails.env.production?
+  require 'ddtrace'
+  Rails.configuration.datadog_trace = {
+    auto_instrument: true,
+    auto_instrument_redis: true,
+    default_service: "Plum (#{Rails.env})"
+  }
+  Datadog::Monkey.patch_all
+end


### PR DESCRIPTION
Datadog should only be initialized in staging or production environments. This PR removes the error message:

```
E, [2017-03-13T17:00:52.579684 #46229] ERROR -- : Failed to open TCP connection to localhost:8126 (Connection refused - connect(2) for "localhost" port 8126)
```