### PR TITLE
Use jQuery 2 instead of 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,6 +121,7 @@ gem 'pul_uv_rails', github: 'pulibrary/pul_uv_rails', branch: 'master'
 gem 'grocer', github: 'pulibrary/grocer'
 source 'https://rails-assets.org' do
   gem 'rails-assets-babel-polyfill'
+  gem 'rails-assets-jquery', '2.2.4'
   gem 'rails-assets-bootstrap-select', '1.9.4'
   gem 'rails-assets-jqueryui-timepicker-addon'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -670,7 +670,7 @@ GEM
     rails-assets-babel-polyfill (0.0.1)
     rails-assets-bootstrap-select (1.9.4)
       rails-assets-jquery (>= 1.8)
-    rails-assets-jquery (3.1.1)
+    rails-assets-jquery (2.2.4)
     rails-assets-jqueryui-timepicker-addon (1.6.3)
     rails-controller-testing (1.0.1)
       actionpack (~> 5.x)
@@ -970,6 +970,7 @@ DEPENDENCIES
   rails (= 5.0.1)
   rails-assets-babel-polyfill!
   rails-assets-bootstrap-select (= 1.9.4)!
+  rails-assets-jquery (= 2.2.4)!
   rails-assets-jqueryui-timepicker-addon!
   rails-controller-testing
   rake (= 11.3.0)

--- a/config/initializers/rails_assets_bypass.rb
+++ b/config/initializers/rails_assets_bypass.rb
@@ -1,3 +1,0 @@
-Rails.configuration.assets.paths.reject! do |path|
-  path.to_s.include?('rails-assets-jquery') && !path.to_s.include?('rails-assets-jqueryui-timepicker')
-end


### PR DESCRIPTION
Blacklight's master branch is using deprecated #size() and we don't have the time to upgrade it at the moment, so in the meantime we can use jQuery 2 which hasn't removed the method yet.

Closes #1073 