### PR TITLE
Using master branch of pul_metadata_services

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'modernizr-rails'
 # gem 'capistrano-rails', group: :development
 
 gem 'hyrax', github: 'projecthydra-labs/hyrax', branch: 'master'
-gem 'pul_metadata_services', github:'pulibrary/pul_metadata_services', branch: 'pulfa-metadata'
+gem 'pul_metadata_services', github:'pulibrary/pul_metadata_services', branch: 'master'
 gem 'hydra-role-management', '~> 0.2.0'
 gem 'rsolr', '~> 1.1.0'
 gem 'devise' , '~> 4.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,8 +128,8 @@ GIT
 
 GIT
   remote: git://github.com/pulibrary/pul_metadata_services.git
-  revision: 08bc4282fbd4b956737d62f52738730a47e75496
-  branch: pulfa-metadata
+  revision: 57a200dd2fa1c21f6611c6bc7683e528c31469dc
+  branch: master
   specs:
     pul_metadata_services (0.0.1)
       activesupport (>= 4.2.7.1)


### PR DESCRIPTION
Switching back to master now that https://github.com/pulibrary/pul_metadata_services/pull/11 is merged.