### PR TITLE
Make BrowseEverythingIngestJob restartable.

### DIFF
--- a/app/forms/file_manager_form.rb
+++ b/app/forms/file_manager_form.rb
@@ -1,4 +1,7 @@
 class FileManagerForm < Hyrax::Forms::FileManagerForm
   self.terms += [:viewing_direction, :viewing_hint, :ocr_language, :start_canvas]
-  delegate :pending_uploads, to: :model
+
+  def pending_uploads
+    model.pending_uploads.where(fileset_id: nil)
+  end
 end

--- a/app/jobs/browse_everything_ingest_job.rb
+++ b/app/jobs/browse_everything_ingest_job.rb
@@ -3,13 +3,21 @@ class BrowseEverythingIngestJob < ApplicationJob
 
   def perform(curation_concern_id, upload_set_id, current_user, selected_files)
     curation_concern = ActiveFedora::Base.find(curation_concern_id)
-    actors = selected_files.map do |_index, file_info|
+    selected_files.map do |_index, file_info|
+      pending_upload = curation_concern.pending_uploads.where(file_path: FilePath.new(file_info["url"]).clean, upload_set_id: upload_set_id).first
+      next if pending_upload.fileset_id.present?
       actor = FileSetActor.new(FileSet.new, current_user)
       BrowseEverythingIngester.new(curation_concern, upload_set_id, actor, file_info).save
-      curation_concern.pending_uploads.where(file_name: file_info["file_name"]).delete_all
-      actor
+      pending_upload.update(fileset_id: actor.file_set.id)
     end
-    curation_concern.ordered_members = actors.map(&:file_set)
+    relevant_uploads = selected_files.values.map do |file|
+      curation_concern.pending_uploads.where(file_path: FilePath.new(file["url"]).clean, upload_set_id: upload_set_id).first
+    end
+    records = relevant_uploads.map do |upload|
+      FileSet.find(upload.fileset_id)
+    end
+    relevant_uploads.each(&:destroy)
+    curation_concern.ordered_members = records
     curation_concern.save
   end
 end

--- a/db/migrate/20170324183854_add_fileset_id_to_pending_uploads.rb
+++ b/db/migrate/20170324183854_add_fileset_id_to_pending_uploads.rb
@@ -1,0 +1,5 @@
+class AddFilesetIdToPendingUploads < ActiveRecord::Migration[5.0]
+  def change
+    add_column :pending_uploads, :fileset_id, :string
+  end
+end

--- a/db/migrate/20170324190231_change_pending_uploads.rb
+++ b/db/migrate/20170324190231_change_pending_uploads.rb
@@ -1,0 +1,8 @@
+class ChangePendingUploads < ActiveRecord::Migration[5.0]
+  def up
+    change_column :pending_uploads, :upload_set_id, :string
+  end
+  def down
+    change_column :pending_uploads, :upload_set_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170322205807) do
+ActiveRecord::Schema.define(version: 20170324190231) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -181,11 +181,12 @@ ActiveRecord::Schema.define(version: 20170322205807) do
 
   create_table "pending_uploads", force: :cascade do |t|
     t.string   "curation_concern_id"
-    t.integer  "upload_set_id"
+    t.string   "upload_set_id"
     t.datetime "created_at",          null: false
     t.datetime "updated_at",          null: false
     t.string   "file_name"
     t.string   "file_path"
+    t.string   "fileset_id"
   end
 
   create_table "permission_template_accesses", force: :cascade do |t|

--- a/spec/views/hyrax/base/file_manager.html.erb_spec.rb
+++ b/spec/views/hyrax/base/file_manager.html.erb_spec.rb
@@ -19,10 +19,9 @@ RSpec.describe "hyrax/base/file_manager.html.erb" do
   let(:parent_solr_doc) do
     SolrDocument.new(parent.to_solr.merge(id: "resource"), nil)
   end
-  let(:pending_upload) { FactoryGirl.build(:pending_upload) }
+  let(:pending_upload) { FactoryGirl.create(:pending_upload, curation_concern_id: parent.id) }
   let(:parent_presenter) do
     s = ScannedResourceShowPresenter.new(parent_solr_doc, nil)
-    allow(s).to receive(:pending_uploads).and_return([pending_upload])
     s
   end
 
@@ -31,9 +30,9 @@ RSpec.describe "hyrax/base/file_manager.html.erb" do
   let(:form) { FileManagerForm.new(parent, nil) }
 
   before do
+    pending_upload
     assign(:form, form)
     allow(form).to receive(:member_presenters).and_return(members)
-    allow(form).to receive(:pending_uploads).and_return([pending_upload])
     stub_blacklight_views
     allow(view).to receive(:curation_concern).and_return(parent)
     allow(view).to receive(:contextual_path).with(anything, anything) do |x, y|
@@ -128,6 +127,13 @@ RSpec.describe "hyrax/base/file_manager.html.erb" do
 
   it "displays pending uploads" do
     expect(rendered).to have_content pending_upload.file_name
+  end
+
+  context "when the pending upload has a file set ID" do
+    let(:pending_upload) { FactoryGirl.create(:pending_upload, fileset_id: "test", curation_concern_id: parent.id) }
+    it "doesn't display it" do
+      expect(rendered).not_to have_content pending_upload.file_name
+    end
   end
 
   it "has inputs to edit the viewing hint" do


### PR DESCRIPTION
If it dies, it'll pick up where it left off by checking the
PendingUploads.

Closes #1125 