### PR TITLE
Use Hyrax description property and add abstract property

### DIFF
--- a/app/adapters/remote_record.rb
+++ b/app/adapters/remote_record.rb
@@ -22,7 +22,7 @@ class RemoteRecord < SimpleDelegator
   def attributes
     result = super
     result[:date] = Array(result.delete(:date_created))
-    result[:description] = Array(result[:description]).first
+    result[:abstract] = Array(result[:abstract]).first
     result.delete :heldBy # TODO: map codes to locations (see plum#1001)
     result[:member_of_collections] = find_or_create(result.delete(:memberOf))
     result

--- a/app/forms/collection_edit_form.rb
+++ b/app/forms/collection_edit_form.rb
@@ -4,7 +4,6 @@ class CollectionEditForm < Hyrax::Forms::CollectionForm
 
   def self.model_attributes(attrs)
     attrs[:title] = Array(attrs[:title]) if attrs[:title]
-    attrs[:description] = Array(attrs[:description]) if attrs[:description]
     super(attrs)
   end
 

--- a/app/forms/hyrax/geo_work_form.rb
+++ b/app/forms/hyrax/geo_work_form.rb
@@ -7,7 +7,7 @@ module Hyrax
     self.required_fields = [:title, :rights_statement, :coverage]
 
     def primary_terms
-      terms = super + [:should_populate_metadata]
+      terms = super + [:description, :should_populate_metadata]
       terms - [:holding_location, :pdf_type, :nav_date, :portion_note, :related_url]
     end
 
@@ -28,7 +28,7 @@ module Hyrax
     end
 
     def multiple?(field)
-      return false if ['description', 'rights_statement'].include?(field.to_s)
+      return false if ['rights_statement'].include?(field.to_s)
       super
     end
   end

--- a/app/forms/hyrax/hyrax_form.rb
+++ b/app/forms/hyrax/hyrax_form.rb
@@ -1,6 +1,6 @@
 module Hyrax
   class HyraxForm < Hyrax::Forms::WorkForm
-    self.terms += [:holding_location, :rights_statement, :rights_note, :source_metadata_identifier, :portion_note, :description, :state, :collection_ids, :ocr_language, :nav_date, :pdf_type, :start_canvas, :uploaded_files]
+    self.terms += [:holding_location, :rights_statement, :rights_note, :source_metadata_identifier, :portion_note, :description, :abstract, :state, :collection_ids, :ocr_language, :nav_date, :pdf_type, :start_canvas, :uploaded_files]
     self.required_fields = [:title, :source_metadata_identifier, :rights_statement]
     delegate :collection_ids, to: :model
 
@@ -9,9 +9,7 @@ module Hyrax
     end
 
     def self.multiple?(field)
-      if field.to_sym == :description
-        false
-      elsif field.to_sym == :pdf_type
+      if field.to_sym == :pdf_type
         false
       elsif field.to_sym == :rights_statement
         false
@@ -36,10 +34,6 @@ module Hyrax
       super
     end
 
-    def description
-      Array.wrap(super).first
-    end
-
     def pdf_type
       if self["pdf_type"].blank?
         "gray"
@@ -57,7 +51,7 @@ module Hyrax
     end
 
     def primary_terms
-      super + [:rights_note, :holding_location, :pdf_type, :portion_note, :description, :nav_date]
+      super + [:rights_note, :holding_location, :pdf_type, :portion_note, :nav_date]
     end
 
     def secondary_terms

--- a/app/forms/hyrax/multi_volume_work_form.rb
+++ b/app/forms/hyrax/multi_volume_work_form.rb
@@ -4,7 +4,7 @@ module Hyrax
     self.terms += [:viewing_direction, :viewing_hint]
 
     def multiple?(field)
-      return false if ['description', 'rights_statement'].include?(field.to_s)
+      return false if ['rights_statement'].include?(field.to_s)
       super
     end
   end

--- a/app/forms/hyrax/scanned_resource_form.rb
+++ b/app/forms/hyrax/scanned_resource_form.rb
@@ -4,7 +4,7 @@ module Hyrax
     self.terms += [:viewing_direction, :viewing_hint]
 
     def multiple?(field)
-      return false if ['description', 'rights_statement'].include?(field.to_s)
+      return false if ['rights_statement'].include?(field.to_s)
       super
     end
   end

--- a/app/schemas/plum_schema.rb
+++ b/app/schemas/plum_schema.rb
@@ -2,7 +2,7 @@
 class PlumSchema < ActiveTriples::Schema
   property :sort_title, predicate: ::OpaqueMods.titleForSort, multiple: false
   property :portion_note, predicate: ::RDF::Vocab::SKOS.scopeNote, multiple: false
-  property :description, predicate: ::RDF::Vocab::DC.abstract, multiple: false
+  property :abstract, predicate: ::RDF::Vocab::DC.abstract, multiple: false
   property :identifier, predicate: ::RDF::Vocab::DC.identifier, multiple: false
   property :replaces, predicate: ::RDF::Vocab::DC.replaces, multiple: false
   property :rights_statement, predicate: ::RDF::Vocab::EDM.rights, multiple: false

--- a/app/views/geo_works/_metadata.html.erb
+++ b/app/views/geo_works/_metadata.html.erb
@@ -5,6 +5,7 @@
   </thead>
   <tbody>
     <%= render 'attribute_rows', presenter: presenter %>
+    <%= presenter.attribute_to_html(:description) %>
     <%= render 'geo_works/attribute_rows', presenter: presenter %>
     <%= presenter.attribute_to_html(:embargo_release_date, render_as: :date) %>
     <%= presenter.attribute_to_html(:lease_expiration_date, render_as: :date) %>

--- a/spec/controllers/hyrax/scanned_resources_controller_spec.rb
+++ b/spec/controllers/hyrax/scanned_resources_controller_spec.rb
@@ -161,7 +161,7 @@ describe Hyrax::ScannedResourcesController do
   end
 
   describe 'update' do
-    let(:scanned_resource_attributes) { { portion_note: 'Section 2', description: 'a description', source_metadata_identifier: '2028405' } }
+    let(:scanned_resource_attributes) { { portion_note: 'Section 2', description: ['a description'], source_metadata_identifier: '2028405' } }
     before do
       sign_in user
     end
@@ -170,7 +170,7 @@ describe Hyrax::ScannedResourcesController do
         post :update, params: { id: scanned_resource, scanned_resource: scanned_resource_attributes }
         expect(reloaded.portion_note).to eq 'Section 2'
         expect(reloaded.title).to eq ['Dummy Title']
-        expect(reloaded.description).to eq 'a description'
+        expect(reloaded.description).to eq ['a description']
       end
       it "can update the start_canvas" do
         post :update, params: { id: scanned_resource, scanned_resource: { start_canvas: "1" } }

--- a/spec/factories/multi_volume_work.rb
+++ b/spec/factories/multi_volume_work.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     title ["Test title"]
     source_metadata_identifier "1234567"
     rights_statement "http://rightsstatements.org/vocab/NKC/1.0/"
-    description "900 years of time and space, and I’ve never been slapped by someone’s mother."
+    description ["900 years of time and space, and I’ve never been slapped by someone’s mother."]
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     state Vocab::FedoraResourceStatus.active
 

--- a/spec/factories/scanned_resources.rb
+++ b/spec/factories/scanned_resources.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     title ["Test title"]
     source_metadata_identifier "1234567"
     rights_statement "http://rightsstatements.org/vocab/NKC/1.0/"
-    description "900 years of time and space, and I’ve never been slapped by someone’s mother."
+    description ["900 years of time and space, and I’ve never been slapped by someone’s mother."]
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     state Vocab::FedoraResourceStatus.active
     pdf_type ["gray"]

--- a/spec/features/edit_multi_volume_work_spec.rb
+++ b/spec/features/edit_multi_volume_work_spec.rb
@@ -20,7 +20,6 @@ RSpec.feature "MultiVolumeWorksController", type: :feature do
     visit edit_polymorphic_path [multi_volume_work]
     fill_in 'multi_volume_work_source_metadata_identifier', with: '1234568'
     fill_in 'multi_volume_work_portion_note', with: 'new portion note'
-    fill_in 'multi_volume_work_description', with: 'new description'
 
     click_button 'Save'
     expect(page).to have_text("Test title")

--- a/spec/features/edit_scanned_resource_spec.rb
+++ b/spec/features/edit_scanned_resource_spec.rb
@@ -26,7 +26,6 @@ RSpec.feature "ScannedResourcesController", type: :feature do
       visit edit_polymorphic_path [scanned_resource]
       fill_in 'scanned_resource_source_metadata_identifier', with: '1234568'
       fill_in 'scanned_resource_portion_note', with: 'new portion note'
-      fill_in 'scanned_resource_description', with: 'new description'
       fill_in 'scanned_resource_nav_date', with: '2016-04-01T01:01:01Z'
       select 'Color PDF', from: 'scanned_resource_pdf_type'
 

--- a/spec/forms/hyrax/multi_volume_work_spec.rb
+++ b/spec/forms/hyrax/multi_volume_work_spec.rb
@@ -5,6 +5,6 @@ RSpec.describe Hyrax::MultiVolumeWorkForm do
   let(:work) { MultiVolumeWork.new }
 
   it "doesn't initialize description" do
-    expect(subject.description).to eq nil
+    expect(subject.description).to eq []
   end
 end

--- a/spec/models/multi_volume_work_spec.rb
+++ b/spec/models/multi_volume_work_spec.rb
@@ -12,13 +12,18 @@ describe MultiVolumeWork do
   subject { multi_volume_work }
 
   describe 'has note fields' do
-    [:portion_note, :description].each do |note_type|
-      it "should let me set a #{note_type}" do
-        note = 'This is note text'
-        subject.send("#{note_type}=", note)
-        expect { subject.save }.to_not raise_error
-        expect(reloaded.send(note_type)).to eq note
-      end
+    it "lets me set a portion_note" do
+      note = 'This is note text'
+      subject.portion_note = note
+      expect { subject.save }.to_not raise_error
+      expect(reloaded.portion_note).to eq note
+    end
+
+    it "lets me set a description" do
+      note = 'This is note text'
+      subject.description = [note]
+      expect { subject.save }.to_not raise_error
+      expect(reloaded.description).to eq [note]
     end
   end
 

--- a/spec/models/scanned_resource_spec.rb
+++ b/spec/models/scanned_resource_spec.rb
@@ -8,13 +8,18 @@ describe ScannedResource do
   subject { scanned_resource }
 
   describe 'has note fields' do
-    [:portion_note, :description].each do |note_type|
-      it "should let me set a #{note_type}" do
-        note = 'This is note text'
-        subject.send("#{note_type}=", note)
-        expect { subject.save }.to_not raise_error
-        expect(reloaded.send(note_type)).to eq note
-      end
+    it "lets me set a portion_note" do
+      note = 'This is note text'
+      subject.portion_note = note
+      expect { subject.save }.to_not raise_error
+      expect(reloaded.portion_note).to eq note
+    end
+
+    it "lets me set a description" do
+      note = 'This is note text'
+      subject.description = [note]
+      expect { subject.save }.to_not raise_error
+      expect(reloaded.description).to eq [note]
     end
   end
 

--- a/spec/services/polymorphic_manifest_builder_spec.rb
+++ b/spec/services/polymorphic_manifest_builder_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe PolymorphicManifestBuilder, vcr: { cassette_name: "iiif_manifest"
       expect(result['@id']).to eq "http://plum.com/concern/scanned_resources/1/manifest"
     end
     it "has a description" do
-      expect(result.description).to eq [record.description]
+      expect(result.description).to eq Array(record.description)
     end
     context "when it has a bibdata ID" do
       it "links to seeAlso" do

--- a/spec/values/scanned_resource_pdf_spec.rb
+++ b/spec/values/scanned_resource_pdf_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ScannedResourcePDF, vcr: { cassette_name: "iiif_manifest" } do
     r.ordered_members << file_set2
     r.logical_order.order = order
     r.title = ["Leonardo's Book é 祝 ي"]
-    r.description = "All about Leonardo."
+    r.description = ["All about Leonardo."]
     r.author = ["Leonardo"]
     solr.add r.to_solr
     solr.add r.list_source.to_solr


### PR DESCRIPTION
- Hyrax `description` property is now used instead of locally defined property.
- Adds `abstract` property.
- Removes description field from SR and MVW work forms.

Closes #1132