### PR TITLE
Only create admin set when needed.

### DIFF
--- a/spec/jobs/ingest_mets_job_spec.rb
+++ b/spec/jobs/ingest_mets_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe IngestMETSJob do
+RSpec.describe IngestMETSJob, :admin_set do
   describe "ingesting a mets file" do
     let(:mets_file) { Rails.root.join("spec", "fixtures", "pudl0001-4612596.mets") }
     let(:mets_file_rtl) { Rails.root.join("spec", "fixtures", "pudl0032-ns73.mets") }

--- a/spec/jobs/ingest_pulfa_job_spec.rb
+++ b/spec/jobs/ingest_pulfa_job_spec.rb
@@ -4,7 +4,7 @@ RSpec::Matchers.define :a_file_named do |x|
   match { |actual| actual.path == x }
 end
 
-RSpec.describe IngestPULFAJob do
+RSpec.describe IngestPULFAJob, :admin_set do
   describe "ingesting a mets file" do
     let(:mets) { fixture('files/AC057-c18.mets') }
     let(:pdf) { fixture('files/test.pdf') }

--- a/spec/models/concerns/state_behavior_spec.rb
+++ b/spec/models/concerns/state_behavior_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe StateBehavior do
+describe StateBehavior, :admin_set do
   describe "when there is no sipity entity" do
     let(:sipityless_resource) { Stateful.new }
     before do

--- a/spec/services/ingest_scanned_maps_service_spec.rb
+++ b/spec/services/ingest_scanned_maps_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe IngestScannedMapsService do
+RSpec.describe IngestScannedMapsService, :admin_set do
   subject { described_class.new(logger) }
   let(:logger) { Logger.new(nil) }
   let(:map_dir) { Rails.root.join('spec', 'fixtures', 'ingest_scanned_maps') }

--- a/spec/services/ingest_service_spec.rb
+++ b/spec/services/ingest_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe IngestService do
+RSpec.describe IngestService, :admin_set do
   subject { described_class.new(logger) }
   let(:logger) { Logger.new(nil) }
   let(:single_dir) { Rails.root.join('spec', 'fixtures', 'ingest_single') }

--- a/spec/services/workflow/plum_workflow_strategy_spec.rb
+++ b/spec/services/workflow/plum_workflow_strategy_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Workflow::PlumWorkflowStrategy, :no_clean do
+RSpec.describe Workflow::PlumWorkflowStrategy, :no_clean, :admin_set do
   context 'when working with a scanned resource' do
     let(:work) { FactoryGirl.build(:scanned_resource) }
     let(:workflow_strategy) { described_class.new(work) }

--- a/spec/support/workflow_resetter.rb
+++ b/spec/support/workflow_resetter.rb
@@ -1,6 +1,8 @@
 RSpec.configure do |config|
   config.before(:each) do
     Hyrax::Workflow::WorkflowImporter.load_workflows
+  end
+  config.before(:each, admin_set: true) do
     AdminSet.find_or_create_default_admin_set_id
   end
 end


### PR DESCRIPTION
Other specs were hitting Fedora whether they needed to or not, including
cleaning up, which was adding over a second per spec.