### PR TITLE
Add ephemera_editor role that can manage ephemera, but not other work types

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -22,6 +22,15 @@ class Ability
     can [:manage], :all
   end
 
+  # Abilities that should be granted to ephemera editors
+  def ephemera_editor_permissions
+    can [:manage], EphemeraBox
+    can [:manage], EphemeraFolder
+    can [:create, :read, :edit, :update, :publish], Collection
+    can [:create, :read, :edit, :update, :publish, :download], FileSet
+    can [:destroy], FileSet, depositor: current_user.uid
+  end
+
   # Abilities that should be granted to technicians
   def image_editor_permissions
     can [:read, :create, :modify, :update, :publish], curation_concerns
@@ -119,6 +128,6 @@ class Ability
     end
 
     def roles
-      ['anonymous', 'campus_patron', 'curator', 'fulfiller', 'editor', 'image_editor', 'admin']
+      ['anonymous', 'campus_patron', 'curator', 'fulfiller', 'editor', 'ephemera_editor', 'image_editor', 'admin']
     end
 end

--- a/app/models/concerns/pul_user_roles.rb
+++ b/app/models/concerns/pul_user_roles.rb
@@ -1,6 +1,10 @@
 module PulUserRoles
   extend ActiveSupport::Concern
 
+  def ephemera_editor?
+    roles.where(name: 'ephemera_editor').exists?
+  end
+
   def image_editor?
     roles.where(name: 'image_editor').exists?
   end

--- a/spec/factories/ephemera_folder.rb
+++ b/spec/factories/ephemera_folder.rb
@@ -3,5 +3,13 @@ FactoryGirl.define do
     title ["Example Folder"]
     folder_number [3]
     identifier ["32101091980639"]
+
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -16,6 +16,10 @@ FactoryGirl.define do
       # All CAS users are campus patrons.
     end
 
+    factory :ephemera_editor do
+      roles { [Role.where(name: 'ephemera_editor').first_or_create] }
+    end
+
     factory :image_editor do
       roles { [Role.where(name: 'image_editor').first_or_create] }
     end


### PR DESCRIPTION
* Allow ephemera_editors to manage ephemera works
* Don't give ephemera editors elevated access to other works

Fixes #1192 