### PR TITLE
Remove Multiple: False

### DIFF
--- a/app/forms/file_manager_form.rb
+++ b/app/forms/file_manager_form.rb
@@ -1,5 +1,8 @@
 class FileManagerForm < Hyrax::Forms::FileManagerForm
+  include SingleValuedForm
   self.terms += [:viewing_direction, :viewing_hint, :ocr_language, :start_canvas]
+  class_attribute :single_valued_fields
+  self.single_valued_fields = [:viewing_hint, :viewing_direction, :start_canvas]
 
   def pending_uploads
     model.pending_uploads.where(fileset_id: nil)

--- a/app/forms/file_set_edit_form.rb
+++ b/app/forms/file_set_edit_form.rb
@@ -1,3 +1,6 @@
 class FileSetEditForm < Hyrax::Forms::FileSetEditForm
+  include SingleValuedForm
   self.terms += [:viewing_hint]
+  class_attribute :single_valued_fields
+  self.single_valued_fields = [:viewing_hint]
 end

--- a/app/forms/hyrax/ephemera_box_form.rb
+++ b/app/forms/hyrax/ephemera_box_form.rb
@@ -1,7 +1,8 @@
 # Generated via
 #  `rails generate hyrax:work EphemeraBox`
 module Hyrax
-  class EphemeraBoxForm < SingleValuedForm
+  class EphemeraBoxForm < ::Hyrax::Forms::WorkForm
+    include SingleValuedForm
     self.model_class = ::EphemeraBox
     self.terms = [:box_number, :identifier, :member_of_collection_ids]
     self.required_fields = [:box_number, :identifier]

--- a/app/forms/hyrax/ephemera_folder_form.rb
+++ b/app/forms/hyrax/ephemera_folder_form.rb
@@ -1,7 +1,8 @@
 # Generated via
 #  `rails generate hyrax:work EphemeraFolder`
 module Hyrax
-  class EphemeraFolderForm < SingleValuedForm
+  class EphemeraFolderForm < ::Hyrax::Forms::WorkForm
+    include SingleValuedForm
     self.model_class = ::EphemeraFolder
     self.terms = [:language, :title, :sort_title, :alternative_title, :series, :creator, :contributor, :publisher, :geographic_origin, :genre, :subject, :geo_subject, :description, :date_created, :identifier, :folder_number, :genre, :width, :height, :page_count, :box_id, :member_of_collection_ids]
     self.required_fields = [:title, :identifier, :folder_number, :width, :height, :page_count, :box_id, :language, :genre]

--- a/app/forms/single_valued_form.rb
+++ b/app/forms/single_valued_form.rb
@@ -1,33 +1,45 @@
-class SingleValuedForm < Hyrax::Forms::WorkForm
-  class_attribute :single_valued_fields
-  self.single_valued_fields = []
+module SingleValuedForm
+  extend ActiveSupport::Concern
+  included do
+    class_attribute :single_valued_fields
+    self.single_valued_fields = []
 
-  def self.multiple?(field)
-    if single_valued_fields.include?(field.to_sym)
-      false
-    else
-      super
-    end
-  end
-
-  def self.model_attributes(form_params)
-    super.tap do |params|
-      single_valued_fields.each do |field|
-        params[field.to_s] = Array.wrap(params[field.to_s])
+    def multiple?(field)
+      if single_valued_fields.include?(field.to_sym)
+        false
+      else
+        super
       end
     end
-  end
 
-  def multiple?(field)
-    if single_valued_fields.include?(field.to_sym)
-      false
-    else
+    def [](key)
+      return super.first if single_valued_fields.include?(key.to_sym)
+      super
+    end
+
+    def initialize_field(key)
+      return if single_valued_fields.include?(key.to_sym)
       super
     end
   end
 
-  def [](key)
-    return super.first if single_valued_fields.include?(key.to_sym)
-    super
+  class_methods do
+    def multiple?(field)
+      if single_valued_fields.include?(field.to_sym)
+        false
+      else
+        super
+      end
+    end
+
+    def model_attributes(form_params)
+      super.tap do |params|
+        single_valued_fields.each do |field|
+          if params.key?(field) || params.key?(field.to_s)
+            params[field.to_s] = Array.wrap(params[field.to_s])
+          end
+        end
+      end
+    end
   end
 end

--- a/app/jobs/ingest_mets_job.rb
+++ b/app/jobs/ingest_mets_job.rb
@@ -20,10 +20,10 @@ class IngestMETSJob < ApplicationJob
       @ingest.delete_duplicates!("identifier_ssim:#{RSolr.solr_escape(@mets.ark_id)}")
       klass = @mets.multi_volume? ? MultiVolumeWork : ScannedResource
       cols = Array(@mets.collection_slugs).select(&:present?).map { |slug| find_or_create_collection(slug) }
-      resource = @ingest.minimal_record(klass, @user, viewing_direction: @mets.viewing_direction,
-                                                      identifier: @mets.ark_id,
-                                                      replaces: @mets.pudl_id,
-                                                      source_metadata_identifier: @mets.bib_id,
+      resource = @ingest.minimal_record(klass, @user, viewing_direction: [@mets.viewing_direction],
+                                                      identifier: [@mets.ark_id],
+                                                      replaces: [@mets.pudl_id],
+                                                      source_metadata_identifier: [@mets.bib_id],
                                                       member_of_collections: cols)
       attach_mets resource
 
@@ -34,7 +34,7 @@ class IngestMETSJob < ApplicationJob
         if @mets.structure.present?
           resource.logical_order.order = map_fileids(@mets.structure)
         end
-        resource.viewing_hint = @mets.viewing_hint
+        resource.viewing_hint = [@mets.viewing_hint]
         resource.save!
         validate!(resource)
       end
@@ -86,7 +86,7 @@ class IngestMETSJob < ApplicationJob
 
     def ingest_file(parent: nil, resource: nil, f: nil, count: 0)
       file_set = @ingest.ingest_file(resource, @mets.decorated_file(f), @user, @mets.file_opts(f),
-                                     title: [@mets.file_label(f[:id])], replaces: f[:replaces])
+                                     title: [@mets.file_label(f[:id])], replaces: [f[:replaces]])
       mets_to_repo_map[f[:id]] = file_set.id
 
       if f[:path] == @mets.thumbnail_path
@@ -107,9 +107,9 @@ class IngestMETSJob < ApplicationJob
 
     def ingest_volumes(parent)
       @mets.volume_ids.each do |volume_id|
-        r = @ingest.minimal_record(ScannedResource, @user, viewing_direction: @mets.viewing_direction,
+        r = @ingest.minimal_record(ScannedResource, @user, viewing_direction: [@mets.viewing_direction],
                                                            title: [@mets.label_for_volume(volume_id)],
-                                                           viewing_hint: @mets.viewing_hint)
+                                                           viewing_hint: [@mets.viewing_hint])
         parent.ordered_members << r
         parent.save!
 

--- a/app/jobs/ingest_pulfa_job.rb
+++ b/app/jobs/ingest_pulfa_job.rb
@@ -24,7 +24,7 @@ class IngestPULFAJob < ApplicationJob
         service = file_info(group.xpath("mets:file[@USE='deliverable']"))
         if master[:file]
           pages << @ingest.ingest_file(r, File.new(master[:file]), @user, {},
-                                       title: [master[:title]], replaces: master[:id])
+                                       title: [master[:title]], replaces: [master[:id]])
         elsif service[:type] == 'application/pdf'
           attach_pdf(r, service)
         end
@@ -38,8 +38,8 @@ class IngestPULFAJob < ApplicationJob
     def work_attributes
       {
         title: [@mets.xpath("//mets:structMap/mets:div/@LABEL").first.value],
-        source_metadata_identifier: replaces.sub(/\//, '_'),
-        replaces: replaces
+        source_metadata_identifier: [replaces.sub(/\//, '_')],
+        replaces: [replaces]
       }
     end
 

--- a/app/models/concerns/apply_remote_metadata.rb
+++ b/app/models/concerns/apply_remote_metadata.rb
@@ -6,10 +6,10 @@ module ApplyRemoteMetadata
 
     def apply_remote_metadata
       if remote_data.source
-        self.source_metadata = remote_data.source.dup.try(:force_encoding, 'utf-8')
+        self.source_metadata = [remote_data.source.dup.try(:force_encoding, 'utf-8')]
       end
       if remote_data.respond_to?(:jsonld)
-        self.source_jsonld = remote_data.jsonld.dup.try(:force_encoding, 'utf-8')
+        self.source_jsonld = [remote_data.jsonld.dup.try(:force_encoding, 'utf-8')]
       end
       self.attributes = enumerable_to_single_valued_attributes(remote_data.attributes)
       CompleteRecord.new(self).complete if workflow_state == 'complete' && identifier.present?
@@ -29,11 +29,11 @@ module ApplyRemoteMetadata
       end
 
       def remote_data
-        @remote_data ||= remote_metadata_factory.retrieve(source_metadata_identifier)
+        @remote_data ||= remote_metadata_factory.retrieve(source_metadata_identifier.first)
       end
 
       def remote_metadata_factory
-        if RemoteRecord.bibdata?(source_metadata_identifier) == 0
+        if RemoteRecord.bibdata?(source_metadata_identifier.first) == 0
           JSONLDRecord::Factory.new(self.class)
         else
           RemoteRecord

--- a/app/models/concerns/common_metadata.rb
+++ b/app/models/concerns/common_metadata.rb
@@ -19,5 +19,20 @@ module CommonMetadata
     validates_with RightsStatementValidator
     validates_with ViewingDirectionValidator
     validates_with ViewingHintValidator
+
+    # We need to check if an array is equal to another array in validators, but
+    # ActiveTriples doesn't return arrays, just AT::Relations.
+    def read_attribute_for_validation(attribute)
+      result = super
+      if result.respond_to?(:each)
+        result.to_a
+      else
+        result
+      end
+    end
+
+    def identifier
+      Array(super).first
+    end
   end
 end

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -8,7 +8,7 @@ class FileSet < ActiveFedora::Base
   characterization_terms << [:color_space, :profile_name, :valid]
   delegate :color_space, :profile_name, :valid, to: :characterization_proxy
 
-  property :replaces, predicate: ::RDF::Vocab::DC.replaces, multiple: false
+  property :replaces, predicate: ::RDF::Vocab::DC.replaces
 
   apply_schema IIIFPageSchema, ActiveFedora::SchemaIndexingStrategy.new(
     ActiveFedora::Indexers::GlobalIndexer.new([:stored_searchable, :symbol])
@@ -56,6 +56,17 @@ class FileSet < ActiveFedora::Base
   def local_file
     pair = id.scan(/..?/).first(4).push(id)
     File.join(Hyrax.config.working_path, *pair, (label || id))
+  end
+
+  # We need to check if an array is equal to another array in validators, but
+  # ActiveTriples doesn't return arrays, just AT::Relations.
+  def read_attribute_for_validation(attribute)
+    result = super
+    if result.respond_to?(:each)
+      result.to_a
+    else
+      result
+    end
   end
 
   private

--- a/app/models/jsonld_record.rb
+++ b/app/models/jsonld_record.rb
@@ -41,7 +41,6 @@ class JSONLDRecord
         ]
       end
 
-    @attributes['sort_title'] = Array(@attributes['sort_title']).first
     @attributes
   end
 

--- a/app/schemas/iiif_book_schema.rb
+++ b/app/schemas/iiif_book_schema.rb
@@ -1,4 +1,4 @@
 class IIIFBookSchema < ActiveTriples::Schema
-  property :viewing_direction, predicate: ::RDF::Vocab::IIIF.viewingDirection, multiple: false
-  property :viewing_hint, predicate: ::RDF::Vocab::IIIF.viewingHint, multiple: false
+  property :viewing_direction, predicate: ::RDF::Vocab::IIIF.viewingDirection
+  property :viewing_hint, predicate: ::RDF::Vocab::IIIF.viewingHint
 end

--- a/app/schemas/iiif_page_schema.rb
+++ b/app/schemas/iiif_page_schema.rb
@@ -1,3 +1,3 @@
 class IIIFPageSchema < ActiveTriples::Schema
-  property :viewing_hint, predicate: ::RDF::Vocab::IIIF.viewingHint, multiple: false
+  property :viewing_hint, predicate: ::RDF::Vocab::IIIF.viewingHint
 end

--- a/app/schemas/plum_schema.rb
+++ b/app/schemas/plum_schema.rb
@@ -1,21 +1,21 @@
 # rubocop:disable Metrics/ClassLength
 class PlumSchema < ActiveTriples::Schema
-  property :sort_title, predicate: ::OpaqueMods.titleForSort, multiple: false
-  property :portion_note, predicate: ::RDF::Vocab::SKOS.scopeNote, multiple: false
-  property :abstract, predicate: ::RDF::Vocab::DC.abstract, multiple: false
+  property :sort_title, predicate: ::OpaqueMods.titleForSort
+  property :portion_note, predicate: ::RDF::Vocab::SKOS.scopeNote
+  property :abstract, predicate: ::RDF::Vocab::DC.abstract
   property :alternative, predicate: ::RDF::Vocab::DC.alternative
-  property :identifier, predicate: ::RDF::Vocab::DC.identifier, multiple: false
-  property :replaces, predicate: ::RDF::Vocab::DC.replaces, multiple: false
-  property :rights_statement, predicate: ::RDF::Vocab::EDM.rights, multiple: false
-  property :rights_note, predicate: ::RDF::Vocab::DC11.rights, multiple: false
-  property :source_metadata_identifier, predicate: ::PULTerms.metadata_id, multiple: false
-  property :source_metadata, predicate: ::PULTerms.source_metadata, multiple: false
-  property :source_jsonld, predicate: ::PULTerms.source_jsonld, multiple: false
-  property :holding_location, predicate: ::RDF::Vocab::Bibframe.heldBy, multiple: false
+  property :identifier, predicate: ::RDF::Vocab::DC.identifier
+  property :replaces, predicate: ::RDF::Vocab::DC.replaces
+  property :rights_statement, predicate: ::RDF::Vocab::EDM.rights
+  property :rights_note, predicate: ::RDF::Vocab::DC11.rights
+  property :source_metadata_identifier, predicate: ::PULTerms.metadata_id
+  property :source_metadata, predicate: ::PULTerms.source_metadata
+  property :source_jsonld, predicate: ::PULTerms.source_jsonld
+  property :holding_location, predicate: ::RDF::Vocab::Bibframe.heldBy
   property :ocr_language, predicate: ::PULTerms.ocr_language
-  property :nav_date, predicate: ::RDF::URI("http://iiif.io/api/presentation/2#navDate"), multiple: false
+  property :nav_date, predicate: ::RDF::URI("http://iiif.io/api/presentation/2#navDate")
   property :pdf_type, predicate: ::PULTerms.pdf_type
-  property :start_canvas, predicate: ::RDF::Vocab::IIIF.hasStartCanvas, multiple: false
+  property :start_canvas, predicate: ::RDF::Vocab::IIIF.hasStartCanvas
   property :container, predicate: ::PULTerms.container
 
   # Generated from Context
@@ -26,7 +26,7 @@ class PlumSchema < ActiveTriples::Schema
   property :source, predicate: RDF::Vocab::DC11.source
   property :extent, predicate: RDF::Vocab::DC.extent
   property :edition, predicate: RDF::URI("http://id.loc.gov/ontologies/bibframe/editionStatement")
-  property :cartographic_scale, predicate: RDF::Vocab::Bibframe.cartographicScale, multiple: false
+  property :cartographic_scale, predicate: RDF::Vocab::Bibframe.cartographicScale
   property :call_number, predicate: PULTerms.call_number
   property :abridger, predicate: RDF::Vocab::MARCRelators.abr
   property :actor, predicate: RDF::Vocab::MARCRelators.act

--- a/app/services/complete_record.rb
+++ b/app/services/complete_record.rb
@@ -45,15 +45,15 @@ class CompleteRecord
     def url
       if record.source_metadata_identifier.blank?
         return ManifestBuilder::ManifestHelper.new.polymorphic_url(record)
-      elsif RemoteRecord.bibdata?(record.source_metadata_identifier)
-        return "https://pulsearch.princeton.edu/catalog/#{record.source_metadata_identifier}#view"
+      elsif RemoteRecord.bibdata?(record.source_metadata_identifier.first)
+        return "https://pulsearch.princeton.edu/catalog/#{record.source_metadata_identifier.first}#view"
       else
-        return "http://findingaids.princeton.edu/collections/#{record.source_metadata_identifier.tr('_', '/')}"
+        return "http://findingaids.princeton.edu/collections/#{record.source_metadata_identifier.first.tr('_', '/')}"
       end
     end
 
     def mint_identifier
-      record.identifier = minter.mint(metadata).id
+      record.identifier = [minter.mint(metadata).id]
       record.save
     end
 end

--- a/app/services/ingest_service.rb
+++ b/app/services/ingest_service.rb
@@ -4,7 +4,7 @@ class IngestService
   end
 
   def minimal_record(klass, user, attributes)
-    default_attributes = { rights_statement: 'http://rightsstatements.org/vocab/NKC/1.0/',
+    default_attributes = { rights_statement: ['http://rightsstatements.org/vocab/NKC/1.0/'],
                            visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     r = klass.new
     r.attributes = default_attributes.merge(attributes)
@@ -19,7 +19,7 @@ class IngestService
 
   def ingest_dir(dir, bib, user, collection = nil)
     klass = choose_class(Dir["#{dir}/*"].first)
-    attribs = bib.nil? ? { title: [File.basename(dir)] } : { source_metadata_identifier: bib }
+    attribs = bib.nil? ? { title: [File.basename(dir)] } : { source_metadata_identifier: [bib] }
     r = minimal_record klass, user, attribs
     members = []
     Dir["#{dir}/*"].sort.each do |f|
@@ -39,7 +39,7 @@ class IngestService
   def ingest_work(file_path, user)
     klass = choose_class(file_path)
     bib_id = File.basename(file_path, '.*')
-    attribs = { source_metadata_identifier: bib_id }
+    attribs = { source_metadata_identifier: [bib_id] }
     r = minimal_record klass, user, attribs
     members = [ingest_file(r, file_path, user, {}, file_set_attributes.merge(title: [bib_id]))]
     r.ordered_members = members

--- a/app/services/manifest_builder/see_also_builder.rb
+++ b/app/services/manifest_builder/see_also_builder.rb
@@ -17,7 +17,7 @@ class ManifestBuilder
       end
 
       def source_metadata_identifier
-        Array(record.try(:source_metadata_identifier)).first
+        Array.wrap(record.try(:source_metadata_identifier)).first
       end
 
       def see_also_hash

--- a/app/services/rights_statement_service.rb
+++ b/app/services/rights_statement_service.rb
@@ -5,7 +5,7 @@ class RightsStatementService < Hyrax::LicenseService
   end
 
   def valid_statements
-    authority.all.map { |hash| hash['id'] }
+    authority.all.map { |hash| [hash['id']] }
   end
 
   def notable?(id)

--- a/app/validators/viewing_direction_validator.rb
+++ b/app/validators/viewing_direction_validator.rb
@@ -17,6 +17,6 @@ class ViewingDirectionValidator < ActiveModel::Validator
         "right-to-left",
         "top-to-bottom",
         "bottom-to-top"
-      ]
+      ].map { |x| Array.wrap(x) }
     end
 end

--- a/app/validators/viewing_hint_validator.rb
+++ b/app/validators/viewing_hint_validator.rb
@@ -18,6 +18,6 @@ class ViewingHintValidator < ActiveModel::Validator
         "individuals",
         "non-paged",
         "facing-pages"
-      ]
+      ].map { |x| Array.wrap(x) }
     end
 end

--- a/app/values/cicognara_csv.rb
+++ b/app/values/cicognara_csv.rb
@@ -10,12 +10,12 @@ class CicognaraCSV
     collection.member_objects.map do |o|
       # parse digital_cico_number from marc
       xp = "//marc:datafield[@tag='024' and marc:subfield/text() = 'dclib']/marc:subfield[@code='a']"
-      dclnum = Nokogiri::XML(o.source_metadata).xpath(xp, marc: 'http://www.loc.gov/MARC21/slim').first.text
+      dclnum = Nokogiri::XML(o.source_metadata.first).xpath(xp, marc: 'http://www.loc.gov/MARC21/slim').first.text
 
       [dclnum, "Plum", manifest_url(o), "Princeton University Library",
-       o.call_number.first, o.source_metadata_identifier, o.identifier,
+       o.call_number.first, o.source_metadata_identifier.first, o.identifier,
        nil, o.publisher.first, Date.parse(o.date_created.first).strftime("%Y"),
-       nil, nil, o.extent.first, o.rights_statement, false]
+       nil, nil, o.extent.first, o.rights_statement.first, false]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,7 @@ Rails.application.routes.draw do
 
   namespace :hyrax, path: :concern do
     resources :parent, only: [] do
-      [:multi_volume_works, :scanned_resources, :ephemera_folder].each do |type|
+      [:multi_volume_works, :scanned_resources, :ephemera_folders].each do |type|
         resources type, only: [] do
           member do
             get :file_manager
@@ -66,6 +66,14 @@ Rails.application.routes.draw do
     resources :scanned_resources, only: [] do
       member do
         get "/pdf/:pdf_quality", action: :pdf, as: :pdf
+        get :structure
+        post :structure, action: :save_structure
+        get :manifest, defaults: { format: :json }
+        post :browse_everything_files
+      end
+    end
+    resources :ephemera_folders, only: [] do
+      member do
         get :structure
         post :structure, action: :save_structure
         get :manifest, defaults: { format: :json }

--- a/spec/ability/roles_spec.rb
+++ b/spec/ability/roles_spec.rb
@@ -33,15 +33,15 @@ describe Ability do
   }
 
   let(:complete_scanned_resource) {
-    FactoryGirl.create(:complete_scanned_resource, user: image_editor, identifier: 'ark:/99999/fk4445wg45')
+    FactoryGirl.create(:complete_scanned_resource, user: image_editor, identifier: ['ark:/99999/fk4445wg45'])
   }
 
   let(:takedown_scanned_resource) {
-    FactoryGirl.create(:takedown_scanned_resource, user: image_editor, identifier: 'ark:/99999/fk4445wg45')
+    FactoryGirl.create(:takedown_scanned_resource, user: image_editor, identifier: ['ark:/99999/fk4445wg45'])
   }
 
   let(:flagged_scanned_resource) {
-    FactoryGirl.create(:flagged_scanned_resource, user: image_editor, identifier: 'ark:/99999/fk4445wg45')
+    FactoryGirl.create(:flagged_scanned_resource, user: image_editor, identifier: ['ark:/99999/fk4445wg45'])
   }
 
   let(:ephemera_editor_file) { FactoryGirl.build(:file_set, user: ephemera_editor) }

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe CatalogController do
     end
 
     it "finds items by their identifier" do
-      resource = FactoryGirl.create(:complete_scanned_resource, source_metadata_identifier: "ab5")
+      resource = FactoryGirl.create(:complete_scanned_resource, source_metadata_identifier: ["ab5"])
 
       get :index, params: { q: "ab5" }
 
@@ -128,7 +128,7 @@ RSpec.describe CatalogController do
   describe "manifest lookup" do
     context "when the manifest is found" do
       it "redirects to the manifest" do
-        resource = FactoryGirl.create(:complete_scanned_resource, identifier: 'ark:/99999/12345678')
+        resource = FactoryGirl.create(:complete_scanned_resource, identifier: ['ark:/99999/12345678'])
         resource.save
 
         get :lookup_manifest, params: { prefix: 'ark:', naan: '99999', arkid: '12345678' }
@@ -136,7 +136,7 @@ RSpec.describe CatalogController do
       end
       context "when no_redirect is set" do
         it "doesn't redirect" do
-          resource = FactoryGirl.create(:complete_scanned_resource, identifier: 'ark:/99999/12345678')
+          resource = FactoryGirl.create(:complete_scanned_resource, identifier: ['ark:/99999/12345678'])
           resource.save
 
           get :lookup_manifest, params: { prefix: 'ark:', naan: '99999', arkid: '12345678', no_redirect: 'true' }

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Hyrax::FileSetsController do
     it "can update viewing_hint" do
       allow_any_instance_of(described_class).to receive(:parent_id).and_return(nil)
       patch :update, params: { id: file_set.id, file_set: { viewing_hint: 'non-paged' } }
-      expect(file_set.reload.viewing_hint).to eq 'non-paged'
+      expect(file_set.reload.viewing_hint).to eq ['non-paged']
     end
     context "when updating via json" do
       render_views
@@ -30,7 +30,7 @@ RSpec.describe Hyrax::FileSetsController do
         patch :update, params: { id: file_set.id, file_set: { viewing_hint: '', title: ["test"] }, format: :json }
         expect(response).to be_success
         file_set.reload
-        expect(file_set.viewing_hint).to eq ""
+        expect(file_set.viewing_hint).to eq []
         expect(file_set.title).to eq ["test"]
       end
     end

--- a/spec/controllers/hyrax/multi_volume_works_controller_spec.rb
+++ b/spec/controllers/hyrax/multi_volume_works_controller_spec.rb
@@ -14,7 +14,8 @@ describe Hyrax::MultiVolumeWorksController do
     context "when given a bib id", vcr: { cassette_name: 'bibdata', allow_playback_repeats: true } do
       let(:multi_volume_work_attributes) do
         FactoryGirl.attributes_for(:multi_volume_work).merge(
-          source_metadata_identifier: "2028405"
+          source_metadata_identifier: "2028405",
+          rights_statement: "http://rightsstatements.org/vocab/NKC/1.0/"
         )
       end
       it "updates the metadata" do

--- a/spec/controllers/hyrax/scanned_resources_controller_spec.rb
+++ b/spec/controllers/hyrax/scanned_resources_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Hyrax::ScannedResourcesController do
   let(:user) { FactoryGirl.create(:user) }
-  let(:scanned_resource) { FactoryGirl.create(:complete_scanned_resource, user: user, title: ['Dummy Title'], identifier: 'ark:/99999/fk4445wg45') }
+  let(:scanned_resource) { FactoryGirl.create(:complete_scanned_resource, user: user, title: ['Dummy Title'], identifier: ['ark:/99999/fk4445wg45']) }
   let(:reloaded) { scanned_resource.reload }
 
   describe "delete" do
@@ -38,7 +38,8 @@ describe Hyrax::ScannedResourcesController do
     context "when given a bib id", vcr: { cassette_name: 'bibdata', record: :new_episodes } do
       let(:scanned_resource_attributes) do
         FactoryGirl.attributes_for(:scanned_resource).merge(
-          source_metadata_identifier: "2028405"
+          source_metadata_identifier:  "2028405",
+          rights_statement: "http://rightsstatements.org/vocab/NKC/1.0/"
         )
       end
       it "updates the metadata" do
@@ -58,7 +59,8 @@ describe Hyrax::ScannedResourcesController do
     context "when given a non-existent bib id", vcr: { cassette_name: 'bibdata_not_found', allow_playback_repeats: true } do
       let(:scanned_resource_attributes) do
         FactoryGirl.attributes_for(:scanned_resource).merge(
-          source_metadata_identifier: "0000000"
+          source_metadata_identifier: "0000000",
+          rights_statement: "http://rightsstatements.org/vocab/NKC/1.0/"
         )
       end
       it "receives an error" do
@@ -80,7 +82,8 @@ describe Hyrax::ScannedResourcesController do
       let(:collection) { FactoryGirl.create(:collection, user: user) }
       let(:scanned_resource_attributes) do
         FactoryGirl.attributes_for(:scanned_resource).except(:source_metadata_identifier).merge(
-          member_of_collection_ids: [collection.id]
+          member_of_collection_ids: [collection.id],
+          rights_statement: "http://rightsstatements.org/vocab/NKC/1.0/"
         )
       end
       it "successfully add the resource to the collection" do
@@ -169,13 +172,13 @@ describe Hyrax::ScannedResourcesController do
     context 'by default' do
       it 'updates the record but does not refresh the exernal metadata' do
         post :update, params: { id: scanned_resource, scanned_resource: scanned_resource_attributes }
-        expect(reloaded.portion_note).to eq 'Section 2'
+        expect(reloaded.portion_note).to eq ['Section 2']
         expect(reloaded.title).to eq ['Dummy Title']
         expect(reloaded.description).to eq ['a description']
       end
       it "can update the start_canvas" do
         post :update, params: { id: scanned_resource, scanned_resource: { start_canvas: "1" } }
-        expect(reloaded.start_canvas).to eq "1"
+        expect(reloaded.start_canvas).to eq ["1"]
       end
       context "when in a collection" do
         let(:scanned_resource) { FactoryGirl.create(:scanned_resource_in_collection, user: user) }
@@ -258,8 +261,8 @@ describe Hyrax::ScannedResourcesController do
     it "updates metadata" do
       post :update, params: { id: scanned_resource.id, scanned_resource: { viewing_hint: 'continuous', viewing_direction: 'bottom-to-top' } }
       scanned_resource.reload
-      expect(scanned_resource.viewing_direction).to eq 'bottom-to-top'
-      expect(scanned_resource.viewing_hint).to eq 'continuous'
+      expect(scanned_resource.viewing_direction).to eq ['bottom-to-top']
+      expect(scanned_resource.viewing_hint).to eq ['continuous']
     end
   end
 

--- a/spec/factories/image_works.rb
+++ b/spec/factories/image_works.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :image_work do
     title ["Test title"]
-    rights_statement "http://rightsstatements.org/vocab/NKC/1.0/"
+    rights_statement ["http://rightsstatements.org/vocab/NKC/1.0/"]
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     state Vocab::FedoraResourceStatus.active
 

--- a/spec/factories/multi_volume_work.rb
+++ b/spec/factories/multi_volume_work.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :multi_volume_work do
     title ["Test title"]
-    source_metadata_identifier "1234567"
-    rights_statement "http://rightsstatements.org/vocab/NKC/1.0/"
+    source_metadata_identifier ["1234567"]
+    rights_statement ["http://rightsstatements.org/vocab/NKC/1.0/"]
     description ["900 years of time and space, and I’ve never been slapped by someone’s mother."]
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     state Vocab::FedoraResourceStatus.active

--- a/spec/factories/scanned_resources.rb
+++ b/spec/factories/scanned_resources.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :scanned_resource do
     title ["Test title"]
-    source_metadata_identifier "1234567"
-    rights_statement "http://rightsstatements.org/vocab/NKC/1.0/"
+    source_metadata_identifier ["1234567"]
+    rights_statement ["http://rightsstatements.org/vocab/NKC/1.0/"]
     description ["900 years of time and space, and I’ve never been slapped by someone’s mother."]
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     state Vocab::FedoraResourceStatus.active

--- a/spec/factories/vector_works.rb
+++ b/spec/factories/vector_works.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :vector_work do
     title ["Test title"]
-    rights_statement "http://rightsstatements.org/vocab/NKC/1.0/"
+    rights_statement ["http://rightsstatements.org/vocab/NKC/1.0/"]
     visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     state Vocab::FedoraResourceStatus.active
 

--- a/spec/forms/single_valued_form_spec.rb
+++ b/spec/forms/single_valued_form_spec.rb
@@ -1,13 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe SingleValuedForm do
-  subject { described_class.new(work, nil, nil) }
+  subject { TestForm.new(work, nil, nil) }
   let(:work) { FactoryGirl.build :ephemera_box }
 
   before do
-    described_class.single_valued_fields = [:identifier]
-    described_class.model_class = ::EphemeraBox
-    described_class.terms = [:identifier, :title]
+    class TestForm < Hyrax::Forms::WorkForm
+      include SingleValuedForm
+    end
+    TestForm.single_valued_fields = [:identifier]
+    TestForm.model_class = ::EphemeraBox
+    TestForm.terms = [:identifier, :title]
+  end
+
+  after do
+    Object.send(:remove_const, :TestForm)
   end
 
   context "an instance" do
@@ -19,14 +26,14 @@ RSpec.describe SingleValuedForm do
 
   context "the class" do
     it "reports single-valued fields" do
-      expect(described_class.multiple?(:identifier)).to be false
-      expect(described_class.multiple?(:title)).to be true
+      expect(TestForm.multiple?(:identifier)).to be false
+      expect(TestForm.multiple?(:title)).to be true
     end
   end
 
   describe "model_attributes" do
     let(:params) { ActionController::Parameters.new(identifier: '123', title: ['Box 1']) }
-    let(:attribs) { described_class.model_attributes(params).to_h }
+    let(:attribs) { TestForm.model_attributes(params).to_h }
 
     it "converts singular fields to arrays" do
       expect(attribs[:identifier]).to eq(['123'])

--- a/spec/jobs/ingest_mets_job_spec.rb
+++ b/spec/jobs/ingest_mets_job_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe IngestMETSJob, :admin_set do
       described_class.perform_now(mets_file, user)
       expect(resource1.title.first.to_s).to eq("Ars minor [fragment].")
       expect(resource1.thumbnail_id).to eq('file1')
-      expect(resource1.viewing_direction).to eq('left-to-right')
+      expect(resource1.viewing_direction).to eq(['left-to-right'])
       expect(resource1.visibility).to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
     end
     context "when an error happens during ingest", vcr: { cassette_name: 'bibdata-4612596' } do
@@ -67,7 +67,7 @@ RSpec.describe IngestMETSJob, :admin_set do
         described_class.perform_now(mets_file, user)
         expect(resource1.title.first.to_s).to eq("Ars minor [fragment].")
         expect(resource1.thumbnail_id).to eq('file1')
-        expect(resource1.viewing_direction).to eq('left-to-right')
+        expect(resource1.viewing_direction).to eq(['left-to-right'])
         expect(resource1.visibility).to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
       end
     end
@@ -94,7 +94,7 @@ RSpec.describe IngestMETSJob, :admin_set do
       allow(actor2).to receive(:attach_file_to_work)
       allow(actor2).to receive(:create_content)
       described_class.perform_now(mets_file_rtl, user)
-      expect(resource1.viewing_direction).to eq('right-to-left')
+      expect(resource1.viewing_direction).to eq(['right-to-left'])
       expect(resource1.ordered_members.to_a.length).to eq 189
     end
 
@@ -191,13 +191,13 @@ RSpec.describe IngestMETSJob, :admin_set do
       expect(resource.reload.logical_order.order).to eq(order.deep_stringify_keys)
       expect(fileset2.reload.title).to eq(['leaf 1. recto'])
       expect(resource.member_of_collections.first.title).to eq(['Scheide Library : Fifteenth-Century Printing'])
-      expect(resource.replaces).to eq('pudl0001/4612596')
-      expect(fileset2.replaces).to eq('pudl0001/4612596/00000001')
+      expect(resource.replaces).to eq(['pudl0001/4612596'])
+      expect(fileset2.replaces).to eq(['pudl0001/4612596/00000001'])
 
       expect(resource.related_objects).to eq([fileset1])
       expect(fileset1.title).to eq(['METS XML'])
       expect(fileset1.files.first.content).to start_with("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<mets:mets")
-      expect(resource.viewing_hint).to eq('paged')
+      expect(resource.viewing_hint).to eq(['paged'])
     end
     context "when there's no isPartOf" do
       let(:mets_file) { Rails.root.join("spec", "fixtures", "pudl0001-4612596-no-collection.mets") }
@@ -209,7 +209,7 @@ RSpec.describe IngestMETSJob, :admin_set do
     end
     context "when the file is already ingested", vcr: { cassette_name: 'bibdata-4612596' } do
       it "deletes the old version" do
-        mvw = FactoryGirl.create(:multi_volume_work_with_file, identifier: "ark:/88435/5m60qr98h")
+        mvw = FactoryGirl.create(:multi_volume_work_with_file, identifier: ["ark:/88435/5m60qr98h"])
         fs = mvw.ordered_members.to_a.first
         allow(described_class.logger).to receive(:info).and_call_original
         described_class.perform_now(mets_file, user)
@@ -221,7 +221,7 @@ RSpec.describe IngestMETSJob, :admin_set do
     end
     context "when there's another resource with a different ark", vcr: { cassette_name: 'bibdata-4612596' } do
       it "doesn't delete it" do
-        FactoryGirl.create(:multi_volume_work_with_file, identifier: "ark:/88435/5m60qr98r")
+        FactoryGirl.create(:multi_volume_work_with_file, identifier: ["ark:/88435/5m60qr98r"])
 
         described_class.perform_now(mets_file, user)
 

--- a/spec/jobs/ingest_pulfa_job_spec.rb
+++ b/spec/jobs/ingest_pulfa_job_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe IngestPULFAJob, :admin_set do
     let(:fileset2) { FileSet.new id: 'fileset2' }
     let(:fileset3) { FileSet.new id: 'fileset3' }
     let(:resource) { ScannedResource.new id: 'resource01' }
-    let(:existing) { FactoryGirl.create(:scanned_resource, replaces: 'AC057/c18') }
+    let(:existing) { FactoryGirl.create(:scanned_resource, replaces: ['AC057/c18']) }
 
     before do
       existing.update_index

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe FileSet do
     expect { subject.save! }.not_to raise_error
   end
 
+  describe "#read_attribute_for_validation" do
+    context "when given a multi-valued field" do
+      it "returns an array" do
+        expect(subject.read_attribute_for_validation(:viewing_hint)).to be_kind_of Array
+      end
+    end
+    context "when given a single valued field" do
+      it "doesn't return an array" do
+        expect(subject.read_attribute_for_validation(:id)).not_to be_kind_of Array
+      end
+    end
+  end
+
   describe "#create_derivatives" do
     let(:delivery_service) { instance_double(GeoWorks::DeliveryService) }
 

--- a/spec/models/image_work_spec.rb
+++ b/spec/models/image_work_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe ImageWork do
-  let(:image_work) { FactoryGirl.build(:image_work, rights_statement: 'http://rightsstatements.org/vocab/NKC/1.0/') }
+  let(:image_work) { FactoryGirl.build(:image_work, rights_statement: ['http://rightsstatements.org/vocab/NKC/1.0/']) }
   subject { image_work }
 
   describe 'apply_remote_metadata' do
@@ -17,7 +17,7 @@ describe ImageWork do
 
     context 'With a Voyager ID', vcr: { cassette_name: "bibdata-maps" } do
       before do
-        subject.source_metadata_identifier = '9284317'
+        subject.source_metadata_identifier = ['9284317']
       end
 
       it 'Extracts Voyager Metadata' do

--- a/spec/models/multi_volume_work_spec.rb
+++ b/spec/models/multi_volume_work_spec.rb
@@ -4,16 +4,16 @@ require 'rails_helper'
 
 describe MultiVolumeWork do
   let(:nkc) { 'http://rightsstatements.org/vocab/NKC/1.0/' }
-  let(:multi_volume_work) { FactoryGirl.build(:multi_volume_work, source_metadata_identifier: '12345', rights_statement: nkc) }
-  let(:scanned_resource1) { FactoryGirl.build(:scanned_resource, title: ['Volume 1'], rights_statement: nkc) }
-  let(:scanned_resource2) { FactoryGirl.build(:scanned_resource, title: ['Volume 2'], rights_statement: nkc) }
+  let(:multi_volume_work) { FactoryGirl.build(:multi_volume_work, source_metadata_identifier: ['12345'], rights_statement: [nkc]) }
+  let(:scanned_resource1) { FactoryGirl.build(:scanned_resource, title: ['Volume 1'], rights_statement: [nkc]) }
+  let(:scanned_resource2) { FactoryGirl.build(:scanned_resource, title: ['Volume 2'], rights_statement: [nkc]) }
   let(:file_set)          { FactoryGirl.build(:file_set) }
   let(:reloaded)          { described_class.find(multi_volume_work.id) }
   subject { multi_volume_work }
 
   describe 'has note fields' do
     it "lets me set a portion_note" do
-      note = 'This is note text'
+      note = ['This is note text']
       subject.portion_note = note
       expect { subject.save }.to_not raise_error
       expect(reloaded.portion_note).to eq note
@@ -29,7 +29,7 @@ describe MultiVolumeWork do
 
   describe 'has source metadata id' do
     it 'allows setting of metadata id' do
-      id = '12345'
+      id = ['12345']
       subject.source_metadata_identifier = id
       expect { subject.save }.to_not raise_error
       expect(reloaded.source_metadata_identifier).to eq id
@@ -48,7 +48,7 @@ describe MultiVolumeWork do
     end
     context "when only metadata id is set" do
       before do
-        subject.source_metadata_identifier = "12355"
+        subject.source_metadata_identifier = ["12355"]
       end
       it 'passes' do
         expect(subject.valid?).to eq true

--- a/spec/presenters/scanned_resource_show_presenter_spec.rb
+++ b/spec/presenters/scanned_resource_show_presenter_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe ScannedResourceShowPresenter do
   end
 
   describe "export linked data", vcr: { cassette_name: 'bibdata-jsonld' } do
-    let(:resource) { FactoryGirl.create(:scanned_resource_in_collection, source_metadata_identifier: '2028405') }
+    let(:resource) { FactoryGirl.create(:scanned_resource_in_collection, source_metadata_identifier: ['2028405']) }
     let(:collection) { resource.member_of_collections.first }
     subject { described_class.new(SolrDocument.new(resource.to_solr), ability) }
 

--- a/spec/services/complete_record_spec.rb
+++ b/spec/services/complete_record_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CompleteRecord do
     context "with a bibdata source_metadata_identifier" do
       let(:bib) { '1234567' }
       let(:metadata) { base_metadata.merge(target: "https://pulsearch.princeton.edu/catalog/#{bib}#view") }
-      let(:obj) { FactoryGirl.build :scanned_resource, source_metadata_identifier: bib, identifier: ark }
+      let(:obj) { FactoryGirl.build :scanned_resource, source_metadata_identifier: [bib], identifier: [ark] }
       it "links to OrangeLight" do
         expect(minter).to receive(:modify).with(ark, metadata)
         subject.complete
@@ -29,7 +29,7 @@ RSpec.describe CompleteRecord do
     context "with a pulfa source_metadata_identifier" do
       let(:cid) { 'AC057/c18' }
       let(:metadata) { base_metadata.merge(target: "http://findingaids.princeton.edu/collections/#{cid}") }
-      let(:obj) { FactoryGirl.build :scanned_resource, source_metadata_identifier: cid, identifier: ark }
+      let(:obj) { FactoryGirl.build :scanned_resource, source_metadata_identifier: [cid], identifier: [ark] }
       it "links to OrangeLight" do
         expect(minter).to receive(:modify).with(ark, metadata)
         subject.complete
@@ -38,7 +38,7 @@ RSpec.describe CompleteRecord do
 
     context "without a source_metadata_identifier" do
       let(:metadata) { base_metadata.merge(target: "http://plum.com/concern/scanned_resources/#{obj.id}") }
-      let(:obj) { FactoryGirl.create :scanned_resource, id: '1234567', identifier: ark, source_metadata_identifier: nil }
+      let(:obj) { FactoryGirl.create :scanned_resource, id: '1234567', identifier: [ark], source_metadata_identifier: nil }
       it "links to OrangeLight" do
         expect(minter).to receive(:modify).with(ark, metadata)
         subject.complete

--- a/spec/services/discovery/geoblacklight_document_spec.rb
+++ b/spec/services/discovery/geoblacklight_document_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Discovery::GeoblacklightDocument do
       visibility: visibility,
       title: ['Geo Work'],
       coverage: coverage.to_s,
-      identifier: 'ark:/99999/fk4'
+      identifier: ['ark:/99999/fk4']
     }
   end
 

--- a/spec/services/discovery/slug_builder_spec.rb
+++ b/spec/services/discovery/slug_builder_spec.rb
@@ -6,7 +6,7 @@ describe Discovery::SlugBuilder do
   let(:document) { instance_double('Document') }
   let(:plum_config) { { geoblacklight_provenance: 'Princeton' } }
   let(:geo_work_presenter) { GeoWorks::VectorWorkShowPresenter.new(SolrDocument.new(geo_work.to_solr), nil) }
-  let(:geo_work) { FactoryGirl.build(:vector_work, identifier: 'ark:/99999/fk4') }
+  let(:geo_work) { FactoryGirl.build(:vector_work, identifier: ['ark:/99999/fk4']) }
 
   before do
     allow(Plum).to receive(:config).and_return(plum_config)

--- a/spec/services/polymorphic_manifest_builder_spec.rb
+++ b/spec/services/polymorphic_manifest_builder_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PolymorphicManifestBuilder, vcr: { cassette_name: "iiif_manifest"
   context "when given a MVW with Children" do
     subject { described_class.new(mvw_document) }
     let(:mvw_document) { ::DynamicShowPresenter.new.new(SolrDocument.new(mvw_record.to_solr), nil) }
-    let(:mvw_record) { FactoryGirl.build(:multi_volume_work, viewing_hint: viewing_hint) }
+    let(:mvw_record) { FactoryGirl.build(:multi_volume_work, viewing_hint: [viewing_hint]) }
     let(:manifest) { JSON.parse(subject.manifest.to_json) }
     let(:viewing_hint) { "individuals" }
     before do
@@ -148,7 +148,7 @@ RSpec.describe PolymorphicManifestBuilder, vcr: { cassette_name: "iiif_manifest"
         record.ordered_members << file_set2
         record.ordered_member_proxies.insert_target_at(0, file_set)
         record.thumbnail = file_set2
-        record.start_canvas = file_set2.id
+        record.start_canvas = [file_set2.id]
         record.logical_order.order = {
           "label": "TOP!",
           "nodes": [
@@ -202,7 +202,7 @@ RSpec.describe PolymorphicManifestBuilder, vcr: { cassette_name: "iiif_manifest"
         expect(manifest_json["sequences"].first["viewingHint"]).to eq "individuals"
       end
       it "has a viewing hint" do
-        file_set.viewing_hint = "non-paged"
+        file_set.viewing_hint = ["non-paged"]
         solr.add file_set.to_solr
         solr.commit
 
@@ -210,7 +210,7 @@ RSpec.describe PolymorphicManifestBuilder, vcr: { cassette_name: "iiif_manifest"
         expect { subject.manifest.to_json }.not_to raise_error
       end
       it "handles facing-pages" do
-        file_set.viewing_hint = "facing-pages"
+        file_set.viewing_hint = ["facing-pages"]
         solr.add file_set.to_solr
         solr.commit
 
@@ -308,7 +308,7 @@ RSpec.describe PolymorphicManifestBuilder, vcr: { cassette_name: "iiif_manifest"
     end
     context "when it has an identifier" do
       it "links to the princeton ark service" do
-        record.identifier = "ark:/88435/7w62fb79g"
+        record.identifier = ["ark:/88435/7w62fb79g"]
         expect(json_result["rendering"]["@id"]).to eq "http://arks.princeton.edu/ark:/88435/7w62fb79g"
         expect(json_result["rendering"]["format"]).to eq "text/html"
       end
@@ -369,7 +369,7 @@ RSpec.describe PolymorphicManifestBuilder, vcr: { cassette_name: "iiif_manifest"
         )
       end
       it "doesn't display sort title" do
-        record.sort_title = "Bla"
+        record.sort_title = ["Bla"]
         expect(result.metadata).to be_empty
       end
       it "doesn't display created" do
@@ -406,14 +406,14 @@ RSpec.describe PolymorphicManifestBuilder, vcr: { cassette_name: "iiif_manifest"
       end
     end
     it "has a viewing hint" do
-      record.viewing_hint = "paged"
+      record.viewing_hint = ["paged"]
       expect(result.viewing_hint).to eq "paged"
     end
     it "has a default viewing hint" do
       expect(result.viewing_hint).to eq "individuals"
     end
     it "has a viewing direction" do
-      record.viewing_direction = "right-to-left"
+      record.viewing_direction = ["right-to-left"]
       expect(result.viewing_direction).to eq "right-to-left"
     end
     it "has a default viewing direction" do

--- a/spec/services/rights_statement_service_spec.rb
+++ b/spec/services/rights_statement_service_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RightsStatementService do
     end
 
     it "lists all valid rights statements" do
-      expect(described_class.new.valid_statements).to eq(valid_statements)
+      expect(described_class.new.valid_statements).to eq(valid_statements.map { |x| [x] })
     end
 
     it "lists select options" do

--- a/spec/validators/rights_statement_validator_spec.rb
+++ b/spec/validators/rights_statement_validator_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RightsStatementValidator do
     valid_statements.each do |statement|
       context "when rights_statement is #{statement}" do
         it "does not add errors" do
-          record = build_record(rights_statement: statement)
+          record = build_record(rights_statement: [statement])
 
           subject.validate(record)
 

--- a/spec/validators/viewing_direction_validator_spec.rb
+++ b/spec/validators/viewing_direction_validator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ViewingDirectionValidator do
     before do
       allow(errors).to receive(:add)
     end
-    ["left-to-right", "right-to-left", "top-to-bottom", "bottom-to-top"].each do |direction|
+    [["left-to-right"], ["right-to-left"], ["top-to-bottom"], ["bottom-to-top"]].each do |direction|
       context "when viewing_direction is #{direction}" do
         it "does not add errors" do
           record = build_record(viewing_direction: direction)
@@ -32,11 +32,11 @@ RSpec.describe ViewingDirectionValidator do
 
     context "when viewing direction is not acceptable" do
       it "adds errors" do
-        record = build_record(viewing_direction: "bad")
+        record = build_record(viewing_direction: ["bad"])
 
         subject.validate(record)
 
-        expect(errors).to have_received(:add).with(:viewing_direction, :inclusion, allow_blank: true, value: "bad")
+        expect(errors).to have_received(:add).with(:viewing_direction, :inclusion, allow_blank: true, value: ["bad"])
       end
     end
   end

--- a/spec/validators/viewing_hint_validator_spec.rb
+++ b/spec/validators/viewing_hint_validator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ViewingHintValidator do
     before do
       allow(errors).to receive(:add)
     end
-    ["individuals", "paged", "continuous"].each do |direction|
+    [["individuals"], ["paged"], ["continuous"]].each do |direction|
       context "when viewing_hint is #{direction}" do
         it "does not add errors" do
           record = build_record(viewing_hint: direction)
@@ -32,11 +32,11 @@ RSpec.describe ViewingHintValidator do
 
     context "when viewing direction is not acceptable" do
       it "adds errors" do
-        record = build_record(viewing_hint: "bad")
+        record = build_record(viewing_hint: ["bad"])
 
         subject.validate(record)
 
-        expect(errors).to have_received(:add).with(:viewing_hint, :inclusion, allow_blank: true, value: "bad")
+        expect(errors).to have_received(:add).with(:viewing_hint, :inclusion, allow_blank: true, value: ["bad"])
       end
     end
   end

--- a/spec/values/cicognara_csv_spec.rb
+++ b/spec/values/cicognara_csv_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CicognaraCSV do
 
   describe "#values", vcr: { cassette_name: "cicognara" } do
     let!(:obj) do
-      obj = FactoryGirl.create :complete_scanned_resource_in_collection, source_metadata_identifier: '2068747'
+      obj = FactoryGirl.create :complete_scanned_resource_in_collection, source_metadata_identifier: ['2068747']
       obj.apply_remote_metadata
       obj.save!
       obj

--- a/spec/values/resource_identifier_spec.rb
+++ b/spec/values/resource_identifier_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ResourceIdentifier do
       scanned_resource.save
       old_id = subject.to_s
 
-      file_set1.viewing_hint = "continuous"
+      file_set1.viewing_hint = ["continuous"]
       file_set1.save
 
       expect(subject.reload.to_s).not_to eq old_id
@@ -50,7 +50,7 @@ RSpec.describe ResourceIdentifier do
       scanned_resource.ordered_members << file_set2
       scanned_resource.ordered_members << file_set3
       scanned_resource.save
-      file_set3.viewing_hint = "continuous"
+      file_set3.viewing_hint = ["continuous"]
       file_set3.save
       old_id = subject.to_s
 

--- a/spec/values/scanned_resource_pdf_spec.rb
+++ b/spec/values/scanned_resource_pdf_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ScannedResourcePDF, vcr: { cassette_name: "iiif_manifest" } do
   subject { described_class.new(presenter) }
   let(:resource) do
-    r = FactoryGirl.build(:scanned_resource, id: "test", holding_location: "https://bibdata.princeton.edu/locations/delivery_locations/3")
+    r = FactoryGirl.build(:scanned_resource, id: "test", holding_location: ["https://bibdata.princeton.edu/locations/delivery_locations/3"])
     r.ordered_members << file_set
     r.ordered_members << file_set2
     r.logical_order.order = order

--- a/spec/voyager_updater/dump_spec.rb
+++ b/spec/voyager_updater/dump_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe VoyagerUpdater::Dump, vcr: { cassette_name: "voyager_dump" }do
     end
     context "when there are records with a matching source metadata identifier" do
       it "returns their record IDs" do
-        s = FactoryGirl.create(:scanned_resource, source_metadata_identifier: "359850")
-        s2 = FactoryGirl.create(:scanned_resource, source_metadata_identifier: "9567836")
+        s = FactoryGirl.create(:scanned_resource, source_metadata_identifier: ["359850"])
+        s2 = FactoryGirl.create(:scanned_resource, source_metadata_identifier: ["9567836"])
         expect(subject.ids_needing_updated).to contain_exactly s.id, s2.id
       end
     end

--- a/spec/voyager_updater/event_spec.rb
+++ b/spec/voyager_updater/event_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe VoyagerUpdater::Event, vcr: { cassette_name: 'voyager_dump' } do
 
   describe "#process!" do
     it "updates all changed records" do
-      s = FactoryGirl.create(:complete_scanned_resource, source_metadata_identifier: "359850")
+      s = FactoryGirl.create(:complete_scanned_resource, source_metadata_identifier: ["359850"])
       subject.process!
 
       expect(s.reload.title.first.to_s).to eq "Coda"

--- a/spec/voyager_updater/event_stream_spec.rb
+++ b/spec/voyager_updater/event_stream_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe VoyagerUpdater::EventStream, vcr: { cassette_name: 'voyager_dump'
 
   describe "#process!" do
     it "updates all changed records and fires events" do
-      s = FactoryGirl.create(:complete_scanned_resource, source_metadata_identifier: "359850")
+      s = FactoryGirl.create(:complete_scanned_resource, source_metadata_identifier: ["359850"])
       manifest_event_generator = instance_double(ManifestEventGenerator)
       allow(ManifestEventGenerator).to receive(:new).and_return(manifest_event_generator)
       allow(manifest_event_generator).to receive(:record_updated)
@@ -25,7 +25,7 @@ RSpec.describe VoyagerUpdater::EventStream, vcr: { cassette_name: 'voyager_dump'
     it "logs errors" do
       logger = spy('logger')
       allow(Rails).to receive(:logger).and_return(logger)
-      s = FactoryGirl.create(:complete_scanned_resource, source_metadata_identifier: "359850")
+      s = FactoryGirl.create(:complete_scanned_resource, source_metadata_identifier: ["359850"])
       allow(ManifestEventGenerator).to receive(:new).and_return(nil)
       subject.process!
 


### PR DESCRIPTION
It's gotten hard to handle which fields are allowed to be multi-valued
and which aren't. In order to deal with conflicts and make the reasoning
much easier to handle, make everything multi-valued and handle
single-valued display via the forms (SingleValuedForm).