### PR TITLE
use plum WorkIndexer for geo works

### DIFF
--- a/app/indexers/geo_work_indexer.rb
+++ b/app/indexers/geo_work_indexer.rb
@@ -1,3 +1,3 @@
-class GeoWorkIndexer < Hyrax::WorkIndexer
+class GeoWorkIndexer < WorkIndexer
   self.thumbnail_path_service = ThumbnailPathService
 end


### PR DESCRIPTION
Uses the Plum WorkIndexer so that the GeoWorks language codes can get properly mapped to labels for faceted search: https://hydra-dev.princeton.edu/catalog?f%5Blanguage_sim%5D%5B%5D=rus&locale=en&q=