### PR TITLE
Add fgdc metadata files to scanned maps

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ Metrics/ClassLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'
     - 'app/jobs/ingest_mets_job.rb'
+    - 'app/services/ingest_existing_scanned_map.rb'
 
 Metrics/CyclomaticComplexity:
   Exclude:

--- a/app/presenters/image_work_show_presenter.rb
+++ b/app/presenters/image_work_show_presenter.rb
@@ -3,4 +3,8 @@ class ImageWorkShowPresenter < GeoWorks::ImageWorkShowPresenter
   delegate :viewing_hint, :viewing_direction, :logical_order, :logical_order_object, :ocr_language,
            :cartographic_projection, :cartographic_scale, :alternative, :edition, :pdf_type,
            :contents, to: :solr_document
+
+  def member_presenter_factory
+    ::EfficientMemberPresenterFactory.new(solr_document, current_ability, request)
+  end
 end

--- a/app/services/manifest_builder/canvas_builder_factory.rb
+++ b/app/services/manifest_builder/canvas_builder_factory.rb
@@ -17,7 +17,11 @@ class ManifestBuilder
 
       def file_set_presenters
         record.member_presenters.select do |x|
-          x.model_name.name == "FileSet"
+          if x.solr_document.key?(:geo_mime_type_tesim)
+            x.solr_document[:geo_mime_type_tesim].include?('image/tiff')
+          else
+            x.model_name.name == "FileSet"
+          end
         end
       end
   end


### PR DESCRIPTION
- Ingest fgdc metadata files for scanned maps if they exist.
- When they are attached to the work, don't include them in the manifest.

Closes #1215 