### PR TITLE
Add Category & Subject CV field.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,7 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Exclude:
     - 'app/indexers/work_indexer.rb'
+    - 'app/services/authority_finder.rb'
 
 Metrics/PerceivedComplexity:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -122,7 +122,7 @@ gem 'grocer', github: 'pulibrary/grocer'
 source 'https://rails-assets.org' do
   gem 'rails-assets-babel-polyfill'
   gem 'rails-assets-jquery', '2.2.4'
-  gem 'rails-assets-bootstrap-select', '1.9.4'
+  gem 'rails-assets-bootstrap-select', '1.12.2'
   gem 'rails-assets-jqueryui-timepicker-addon'
 end
 gem 'poltergeist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -668,7 +668,7 @@ GEM
       railties (= 5.0.1)
       sprockets-rails (>= 2.0.0)
     rails-assets-babel-polyfill (0.0.1)
-    rails-assets-bootstrap-select (1.9.4)
+    rails-assets-bootstrap-select (1.12.2)
       rails-assets-jquery (>= 1.8)
     rails-assets-jquery (2.2.4)
     rails-assets-jqueryui-timepicker-addon (1.6.3)
@@ -961,7 +961,7 @@ DEPENDENCIES
   pul_uv_rails!
   rails (= 5.0.1)
   rails-assets-babel-polyfill!
-  rails-assets-bootstrap-select (= 1.9.4)!
+  rails-assets-bootstrap-select (= 1.12.2)!
   rails-assets-jquery (= 2.2.4)!
   rails-assets-jqueryui-timepicker-addon!
   rails-controller-testing

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -28,7 +28,7 @@ class WorkIndexer < Hyrax::WorkIndexer
         solr_doc[Solrizer.solr_name("#{field}_literals", :symbol)] = output
       end
       solr_doc[Solrizer.solr_name("identifier", :symbol)] = object.identifier
-      [:geo_subject, :geographic_origin, :genre].each do |property|
+      [:geo_subject, :geographic_origin, :genre, :subject].each do |property|
         next unless object.respond_to?(property)
         solr_doc[Solrizer.solr_name(property.to_s, :facetable)] = object.send(property).map do |code|
           authority = AuthorityFinder.for(property: property, model: object)

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -35,6 +35,12 @@ class WorkIndexer < Hyrax::WorkIndexer
           authority.find(code)[:label] if authority
         end.compact
       end
+      subject_authority = AuthorityFinder.for(property: :subject, model: object)
+      if subject_authority
+        solr_doc[Solrizer.solr_name("category", :facetable)] = object.send(:subject).map do |code|
+          subject_authority.find(code)[:vocabulary] if subject_authority
+        end.compact
+      end
       solr_doc[Solrizer.solr_name("language", :facetable)] = object.language.map do |code|
         AuthorityFinder.for(property: :language, model: object).try(:find, code).try(:[], :label) || LanguageService.label(code)
       end

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -2,6 +2,7 @@ class Vocabulary < ApplicationRecord
   belongs_to :parent, class_name: "Vocabulary"
   validates :label, presence: true
   after_create :register_authority
+  has_many :vocabulary_terms
 
   def register_authority
     Qa::Authorities::Local.register_subauthority(label, 'VocabularySubauthority')

--- a/app/models/vocabulary_subauthority.rb
+++ b/app/models/vocabulary_subauthority.rb
@@ -26,7 +26,11 @@ class VocabularySubauthority < Qa::Authorities::Base
       Vocabulary.where(parent_id: @vocabulary.id).to_a
     end
 
+    def vocabulary(item)
+      item.try(:vocabulary) || item.try(:parent)
+    end
+
     def format_item(item)
-      { id: item.id, label: item.label, type: item.class.name, active: true }.with_indifferent_access
+      { id: item.id, label: item.label, type: item.class.name, vocabulary: vocabulary(item).try(:label), active: true }.with_indifferent_access
     end
 end

--- a/app/presenters/ephemera_folder_presenter.rb
+++ b/app/presenters/ephemera_folder_presenter.rb
@@ -31,6 +31,12 @@ class EphemeraFolderPresenter < HyraxShowPresenter
     end
   end
 
+  def subject
+    Array.wrap(solr_document.subject).map do |id|
+      authority_for(:subject).find(id)[:label]
+    end
+  end
+
   def authority_for(property)
     AuthorityFinder.for(property: property, model: self) || NullAuthority
   end

--- a/app/services/authority_finder.rb
+++ b/app/services/authority_finder.rb
@@ -9,6 +9,8 @@ class AuthorityFinder
         Qa::Authorities::Local.subauthority_for('Geographic Origin')
       when :genre
         Qa::Authorities::Local.subauthority_for('Genre')
+      when :subject
+        Qa::Authorities::Local.subauthority_for('Subjects')
       end
     rescue Qa::InvalidSubAuthority
       Rails.logger.debug("Non-existent sub-authority requested for property #{property}")

--- a/app/services/ingest_vocab.rb
+++ b/app/services/ingest_vocab.rb
@@ -8,7 +8,7 @@ class IngestVocab
     CSV.foreach(file, headers: true) do |obj|
       row = obj.to_h
       category_label = fetch(row, columns, :category)
-      category = Vocabulary.find_or_create_by!(label: category_label) if category_label
+      category = Vocabulary.find_or_create_by!(label: category_label, parent: vocab) if category_label
       VocabularyTerm.create!(
         label: fetch(row, columns, :label),
         tgm_label: fetch(row, columns, :tgm_label),

--- a/app/services/vocabulary_select_service.rb
+++ b/app/services/vocabulary_select_service.rb
@@ -1,0 +1,46 @@
+class VocabularySelectService
+  attr_reader :authority
+
+  def initialize(authority_name)
+    @authority = Qa::Authorities::Local.subauthority_for(authority_name)
+  end
+
+  def select_all_options
+    authority.all.map do |vocab|
+      Option.for(vocab)
+    end
+  end
+
+  class Option
+    def self.for(vocab)
+      case vocab[:type]
+      when "Vocabulary"
+        VocabularyOption.new(vocab)
+      else
+        Option.new(vocab)
+      end
+    end
+
+    class VocabularyOption < Option
+      def child_terms
+        VocabularySelectService.new(label).select_all_options
+      end
+    end
+    attr_reader :element
+    def initialize(element)
+      @element = element
+    end
+
+    def label
+      element[:label]
+    end
+
+    def id
+      element[:id]
+    end
+
+    def child_terms
+      []
+    end
+  end
+end

--- a/app/views/records/edit_fields/_controlled_field.html.erb
+++ b/app/views/records/edit_fields/_controlled_field.html.erb
@@ -4,7 +4,13 @@
   <%= f.input key,
     collection: options.select_active_options,
     include_blank: true,
-    input_html: { class: 'form-control', multiple: f.object.multiple?(key) } %>
+    input_html: {
+      class: 'form-control',
+      multiple: f.object.multiple?(key),
+      data: {
+        live_search: true
+      }
+    } %>
 <% else %>
   <%= render "records/edit_fields/default", f: f, key: key%>
 <% end %>

--- a/app/views/records/edit_fields/_subject.html.erb
+++ b/app/views/records/edit_fields/_subject.html.erb
@@ -1,0 +1,22 @@
+<% authority = AuthorityFinder.for(property: key, model: f.object) %>
+<% if authority %>
+  <% options = VocabularySelectService.new(authority.subauthority_name) %>
+  <%= f.input key,
+    collection: options.select_all_options,
+    as: :grouped_select,
+    include_blank: true,
+    group_method: :child_terms,
+    group_label_method: :label,
+    label_method: :label,
+    value_method: :id,
+    input_html: { 
+      class: 'form-control', 
+      multiple: f.object.multiple?(key),
+      data: {
+        live_search: true
+      }
+    }
+  %>
+<% else %>
+  <%= render "records/edit_fields/default", f: f, key: key%>
+<% end %>

--- a/spec/models/ephemera_folder_spec.rb
+++ b/spec/models/ephemera_folder_spec.rb
@@ -124,6 +124,29 @@ RSpec.describe EphemeraFolder do
     end
   end
 
+  describe "Subject Indexing" do
+    context "when given a set of subject IDs" do
+      after do
+        Qa::Authorities::Local.registry.instance_variable_get(:@hash).delete("Subjects")
+      end
+      before do
+        Qa::Authorities::Local.registry.instance_variable_get(:@hash).delete("Subjects")
+        vocabulary
+      end
+      let(:vocabulary) do
+        Vocabulary.create!(label: "Subjects").tap do |vocab|
+          Vocabulary.create!(label: "Test", parent: vocab).tap do |vocab_2|
+            VocabularyTerm.create!(vocabulary: vocab_2, label: "English")
+          end
+        end
+      end
+      let(:folder) { FactoryGirl.build(:ephemera_folder, subject: [VocabularyTerm.first.id.to_s]) }
+      it "Returns the label for the IDs" do
+        expect(folder.to_solr["subject_sim"]).to eq ["English"]
+      end
+    end
+  end
+
   describe "box and box_id" do
     let(:box) { FactoryGirl.create :ephemera_box }
     let(:col) { FactoryGirl.build :collection }

--- a/spec/models/ephemera_folder_spec.rb
+++ b/spec/models/ephemera_folder_spec.rb
@@ -143,6 +143,7 @@ RSpec.describe EphemeraFolder do
       let(:folder) { FactoryGirl.build(:ephemera_folder, subject: [VocabularyTerm.first.id.to_s]) }
       it "Returns the label for the IDs" do
         expect(folder.to_solr["subject_sim"]).to eq ["English"]
+        expect(folder.to_solr["category_sim"]).to eq ["Test"]
       end
     end
   end

--- a/spec/models/vocabulary_subauthority_spec.rb
+++ b/spec/models/vocabulary_subauthority_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe VocabularySubauthority, type: :model do
   subject { described_class.new(parent.label) }
 
   it 'lists terms and vocabularies' do
-    child_hash = { id: child.id, label: child.label, type: child.class.name, active: true }.with_indifferent_access
-    term_hash = { id: term.id, label: term.label, type: term.class.name, active: true }.with_indifferent_access
+    child_hash = { id: child.id, label: child.label, type: child.class.name, vocabulary: 'Parent Vocabulary', active: true }.with_indifferent_access
+    term_hash = { id: term.id, label: term.label, type: term.class.name, vocabulary: 'Parent Vocabulary', active: true }.with_indifferent_access
     expect(subject.all).to contain_exactly(child_hash, term_hash)
   end
 
   it 'finds terms by their ids' do
-    term_hash = { id: term.id, label: term.label, type: term.class.name, active: true }.with_indifferent_access
+    term_hash = { id: term.id, label: term.label, type: term.class.name, vocabulary: 'Parent Vocabulary', active: true }.with_indifferent_access
     expect(subject.find(term.id)).to eq(term_hash)
   end
 end

--- a/spec/presenters/ephemera_folder_presenter_spec.rb
+++ b/spec/presenters/ephemera_folder_presenter_spec.rb
@@ -108,6 +108,36 @@ RSpec.describe EphemeraFolderPresenter do
     end
   end
 
+  describe "#subject" do
+    context "when given a set of genre IDs" do
+      after do
+        Qa::Authorities::Local.registry.instance_variable_get(:@hash).delete("Subjects")
+      end
+      before do
+        Qa::Authorities::Local.registry.instance_variable_get(:@hash).delete("Subjects")
+        vocabulary
+      end
+      let(:vocabulary) do
+        Vocabulary.create!(label: "Subjects").tap do |vocab|
+          Vocabulary.create!(label: "Test", parent: vocab).tap do |vocab_2|
+            VocabularyTerm.create!(vocabulary: vocab_2, label: "English")
+          end
+        end
+      end
+      let(:folder) { FactoryGirl.build(:ephemera_folder, subject: [VocabularyTerm.first.id.to_s]) }
+      it "Returns the label for the IDs" do
+        expect(subject.subject).to eq ["English"]
+      end
+    end
+
+    context "when there's no vocabulary" do
+      let(:folder) { FactoryGirl.build(:ephemera_folder, subject: ["Test"]) }
+      it "works" do
+        expect(subject.subject).to eq ["Test"]
+      end
+    end
+  end
+
   describe "#renderer_for" do
     it "renders identifier as a barcodde" do
       expect(subject.renderer_for(:identifier, {})).to be BarcodeAttributeRenderer

--- a/spec/services/ingest_vocab_spec.rb
+++ b/spec/services/ingest_vocab_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe IngestVocab do
       end
     end
 
+    context "with categories & a parent vocab name" do
+      before do
+        described_class.ingest(subject_csv, "LAE Subjects", label: 'subject', category: 'category', uri: 'uri')
+      end
+
+      it "loads the terms with categories & a parent vocab" do
+        expect(VocabularyTerm.all.map(&:label)).to contain_exactly('Agricultural development projects', 'Architecture')
+        expect(Vocabulary.all.map(&:label)).to contain_exactly('LAE Subjects', 'Agrarian and rural issues', 'Arts and culture')
+        expect(Vocabulary.where(label: "Arts and culture").first.parent.label).to eq 'LAE Subjects'
+      end
+    end
+
     context "without categories" do
       before do
         described_class.ingest(genre_csv, "Genres", label: 'pul_label', tgm_label: 'tgm_label', lcsh_label: 'lcsh_label', uri: 'uri')

--- a/spec/services/vocabulary_select_service_spec.rb
+++ b/spec/services/vocabulary_select_service_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe VocabularySelectService do
+  let(:vocabulary_label) { "Subjects" }
+  let(:vocabulary) do
+    Vocabulary.create!(label: "Subjects").tap do |vocab|
+      Vocabulary.create!(label: "Test", parent: vocab).tap do |vocab_2|
+        VocabularyTerm.create!(vocabulary: vocab_2, label: "English")
+      end
+    end
+  end
+  subject(:select_service) { described_class.new(vocabulary_label) }
+  before do
+    Qa::Authorities::Local.registry.instance_variable_get(:@hash).delete(vocabulary_label)
+    Qa::Authorities::Local.registry.instance_variable_get(:@hash).delete("Test")
+    vocabulary
+  end
+  after do
+    Qa::Authorities::Local.registry.instance_variable_get(:@hash).delete(vocabulary_label)
+    Qa::Authorities::Local.registry.instance_variable_get(:@hash).delete("Test")
+  end
+  context "when given a vocabulary with terms" do
+    let(:vocabulary_label) { "Test" }
+    it "returns options without child_terms" do
+      expect(select_service.select_all_options.first.child_terms).to eq []
+    end
+  end
+  context "when given a vocabulary with a sub-vocabulary" do
+    it "returns options with child_terms" do
+      expect(select_service.select_all_options.first.child_terms).not_to be_empty
+    end
+  end
+end

--- a/spec/views/records/edit_fields/_subject.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_subject.html.erb_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+include SimpleForm::ActionViewExtensions::FormHelper
+
+RSpec.describe 'records/edit_fields/_subject.html.erb' do
+  let(:vocabulary) { nil }
+  let(:vocabulary_label) { "Subject" }
+  before do
+    Qa::Authorities::Local.registry.instance_variable_get(:@hash).delete(vocabulary_label)
+    allow(view).to receive(:f).and_return(simple_form_for(form))
+    allow(view).to receive(:key).and_return(:subject)
+    vocabulary
+    render
+  end
+  after do
+    Qa::Authorities::Local.registry.instance_variable_get(:@hash).delete(vocabulary_label)
+  end
+
+  context 'with an ephemera folder' do
+    let(:form) { Hyrax::EphemeraFolderForm.new(EphemeraFolder.new, nil, nil) }
+    context "when there is no subject vocabulary" do
+      it "doesn't create a select box" do
+        expect(rendered).not_to have_selector "select"
+      end
+    end
+    context "when there is a subject vocabulary" do
+      let(:vocabulary) do
+        Vocabulary.create!(label: "Subjects").tap do |vocab|
+          Vocabulary.create!(label: "Test", parent: vocab).tap do |vocab_2|
+            VocabularyTerm.create!(vocabulary: vocab_2, label: "English")
+          end
+        end
+      end
+      let(:folder) { FactoryGirl.build(:ephemera_folder, subject: [VocabularyTerm.first.id.to_s]) }
+      it "creates a select box" do
+        expect(rendered).to have_select("Subject", options: ['', 'English'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This uses `<optgroup>` and bootstrap-select instead of the home-built
javascript picker in the current LAE. I hope this is sufficient, because
the HTML is much more standard, and even without bootstrap-select you
get a nice categorized multiple-select box.
![screen shot 2017-05-09 at 3 25 04 pm](https://cloud.githubusercontent.com/assets/2806645/25876590/023b4d84-34d3-11e7-91ee-8011ac812259.png)

