### PR TITLE
Fixes specs for cleanup-derivatives method

### DIFF
--- a/spec/services/geo_derivative_service_spec.rb
+++ b/spec/services/geo_derivative_service_spec.rb
@@ -20,12 +20,14 @@ RSpec.describe GeoDerivativesService do
     let(:factory) { class_double('PairtreeDerivativePath') }
     before do
       allow(subject).to receive(:derivative_path_factory).and_return(factory)
-      allow(factory).to receive(:derivatives_for_reference).and_return(tmpfile)
+      allow(factory).to receive(:derivatives_for_reference).and_return([tmpfile])
     end
 
     it "removes the files" do
-      subject.cleanup_derivatives
-      expect(File.exist?(tmpfile.path)).to be true
+      expect {
+        subject.cleanup_derivatives
+      }.to change { File.exist?(tmpfile.path) }
+        .from(true).to(false)
     end
   end
 end

--- a/spec/services/plum_derivative_service_spec.rb
+++ b/spec/services/plum_derivative_service_spec.rb
@@ -20,12 +20,14 @@ RSpec.describe PlumDerivativesService do
     let(:factory) { class_double('PairtreeDerivativePath') }
     before do
       allow(subject).to receive(:derivative_path_factory).and_return(factory)
-      allow(factory).to receive(:derivatives_for_reference).and_return(tmpfile)
+      allow(factory).to receive(:derivatives_for_reference).and_return([tmpfile])
     end
 
     it "removes the files" do
-      subject.cleanup_derivatives
-      expect(File.exist?(tmpfile.path)).to be true
+      expect {
+        subject.cleanup_derivatives
+      }.to change { File.exist?(tmpfile.path) }
+        .from(true).to(false)
     end
   end
 end

--- a/spec/services/scanned_map_derivatives_service_spec.rb
+++ b/spec/services/scanned_map_derivatives_service_spec.rb
@@ -49,12 +49,14 @@ RSpec.describe ScannedMapDerivativesService do
     let(:factory) { class_double(PairtreeDerivativePath) }
     before do
       allow(subject).to receive(:derivative_path_factory).and_return(factory)
-      allow(factory).to receive(:derivatives_for_reference).and_return(tmpfile)
+      allow(factory).to receive(:derivatives_for_reference).and_return([tmpfile])
     end
 
     it "removes the files" do
-      subject.cleanup_derivatives
-      expect(File.exist?(tmpfile.path)).to be true
+      expect {
+        subject.cleanup_derivatives
+      }.to change { File.exist?(tmpfile.path) }
+        .from(true).to(false)
     end
   end
 end


### PR DESCRIPTION
The specs for `cleanup-derivatives` in #1282 weren't actually testing if the derivative was removed or not. The main reason is the `derivatives_for_reference` should return an array rather than a single value.