### PR TITLE
Add workflow for LAE Folders

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,7 @@ Metrics/ClassLength:
     - 'app/controllers/catalog_controller.rb'
     - 'app/jobs/ingest_mets_job.rb'
     - 'app/services/ingest_existing_scanned_map.rb'
+    - 'app/models/ability.rb'
 
 Metrics/CyclomaticComplexity:
   Exclude:

--- a/app/forms/hyrax/ephemera_folder_form.rb
+++ b/app/forms/hyrax/ephemera_folder_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   class EphemeraFolderForm < ::Hyrax::Forms::WorkForm
     include SingleValuedForm
     self.model_class = ::EphemeraFolder
-    self.terms = [:identifier, :folder_number, :title, :sort_title, :alternative_title, :language, :genre, :width, :height, :page_count, :box_id, :rights_statement, :series, :creator, :contributor, :publisher, :geographic_origin, :subject, :geo_subject, :description, :date_created, :member_of_collection_ids]
+    self.terms = [:identifier, :folder_number, :title, :sort_title, :alternative_title, :language, :genre, :width, :height, :page_count, :box_id, :rights_statement, :series, :creator, :contributor, :publisher, :geographic_origin, :subject, :geo_subject, :description, :date_created, :member_of_collection_ids, :visibility]
     self.required_fields = [:title, :identifier, :folder_number, :width, :height, :page_count, :box_id, :language, :genre, :rights_statement]
     self.single_valued_fields = [:title, :sort_title, :creator, :geographic_origin, :date_created, :genre, :description, :identifier, :folder_number, :genre, :width, :height, :page_count, :rights_statement]
     delegate :box_id, to: :model

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -93,6 +93,9 @@ class Ability
     cannot [:read], curation_concerns do |curation_concern|
       !readable_concern?(curation_concern)
     end
+    cannot [:manifest], EphemeraFolder do |folder|
+      folder.workflow_state == "needs_qa"
+    end
     can :pdf, (curation_concerns + [ScannedResourceShowPresenter]) do |curation_concern|
       ["color", "gray"].include?(Array(curation_concern.pdf_type).first)
     end

--- a/app/presenters/ephemera_folder_presenter.rb
+++ b/app/presenters/ephemera_folder_presenter.rb
@@ -1,4 +1,5 @@
 class EphemeraFolderPresenter < HyraxShowPresenter
+  include PlumAttributes
   self.collection_presenter_class = DynamicShowPresenter.new
   delegate :folder_number, to: :solr_document
 

--- a/app/presenters/state_badge.rb
+++ b/app/presenters/state_badge.rb
@@ -47,6 +47,7 @@ class StateBadge
     def state_classes
       @state_classes ||= {
         pending: 'label-default',
+        needs_qa: 'label-info',
         metadata_review: 'label-info',
         final_review: 'label-primary',
         complete: 'label-success',

--- a/app/services/workflow/folders/grant_edit_to_groups.rb
+++ b/app/services/workflow/folders/grant_edit_to_groups.rb
@@ -1,0 +1,9 @@
+module Workflow
+  module Folders
+    class GrantEditToGroups
+      def self.call(target:, **)
+        target.edit_groups = ['admin', 'ephemera_editor']
+      end
+    end
+  end
+end

--- a/app/services/workflow/plum_workflow_strategy.rb
+++ b/app/services/workflow/plum_workflow_strategy.rb
@@ -9,6 +9,7 @@ module Workflow
     # @return [String] The name of the workflow to use
     def workflow
       return Sipity::Workflow.where(name: 'book_works').first! if book_works.include? work_class
+      return Sipity::Workflow.where(name: 'folder_works').first! if folder_works.include? work_class
       return Sipity::Workflow.where(name: 'geo_works').first! if geo_works.include? work_class
     end
 
@@ -19,7 +20,11 @@ module Workflow
       end
 
       def book_works
-        %w(ScannedResource MultiVolumeWork EphemeraBox EphemeraFolder)
+        %w(ScannedResource MultiVolumeWork EphemeraBox)
+      end
+
+      def folder_works
+        %w(EphemeraFolder)
       end
 
       def geo_works

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -1,4 +1,4 @@
-<% if presenter.respond_to?(:member_presenters) && presenter.member_presenters.present? %>
+<% if can?(:manifest, presenter) && presenter.respond_to?(:member_presenters) && presenter.member_presenters.present? %>
   <div class="uv viewer" data-config="/uv_config.json" data-uri="<%= main_app.polymorphic_path([main_app,:manifest,presenter]) %>" ></div>
   <%= PulUvRails::UniversalViewer.script_tag %>
 <% else %>

--- a/app/views/hyrax/ephemera_boxes/_representative_media.html.erb
+++ b/app/views/hyrax/ephemera_boxes/_representative_media.html.erb
@@ -1,1 +1,0 @@
-<%= image_tag 'nope.png', class: "canonical-image" %>

--- a/app/views/hyrax/ephemera_folders/show.html.erb
+++ b/app/views/hyrax/ephemera_folders/show.html.erb
@@ -16,6 +16,5 @@
 
 <%= render '/hyrax/base/representative_media', presenter: @presenter %>
 <%= render "/hyrax/base/attributes", presenter: @presenter %>
-<%= render "/hyrax/base/items", presenter: @presenter %>
 <%= render 'workflow_actions', presenter: @presenter if @presenter.workflow.actions.present? %>
 <%= render "show_actions", collector: collector, editor: editor%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,9 @@ en:
     complete:
       label: 'Complete'
       desc:  'Published and accessible according to access control rules'
+    needs_qa:
+      label: 'Needs QA'
+      desc: 'Awaiting approval for images to be public.'
     flagged:
       label: 'Flagged'
       desc:  'In need of attention, but still accessible according to access rules'

--- a/config/workflows/folder_workflow.json
+++ b/config/workflows/folder_workflow.json
@@ -1,0 +1,50 @@
+{
+  "workflows": [
+    {
+      "name": "folder_works",
+      "label": "Folder Works",
+      "actions": [
+        {
+          "name": "new",
+          "from_states": [],
+          "transition_to": "needs_qa",
+          "methods": [
+            "Workflow::Folders::GrantEditToGroups",
+            "Hyrax::Workflow::ActivateObject"
+          ]
+        },
+        {
+          "name": "needs_qa",
+          "from_states": [
+            {
+              "names": ["complete"],
+              "roles": [
+                "admin",
+                "ephemera_editor"
+              ]
+            }
+          ],
+          "methods": [
+          ],
+          "transition_to": "needs_qa"
+        },
+        {
+          "name": "complete",
+          "from_states": [
+            {
+              "names": ["needs_qa"],
+              "roles": [
+                "admin",
+                "ephemera_editor"
+              ]
+            }
+          ],
+          "methods": [
+            "Workflow::CompleteRecord"
+          ],
+          "transition_to": "complete"
+        }
+      ]
+    }
+  ]
+}

--- a/spec/ability/roles_spec.rb
+++ b/spec/ability/roles_spec.rb
@@ -44,6 +44,14 @@ describe Ability do
     FactoryGirl.create(:flagged_scanned_resource, user: image_editor, identifier: ['ark:/99999/fk4445wg45'])
   }
 
+  let(:complete_ephemera_folder) {
+    FactoryGirl.create(:complete_ephemera_folder, user: creating_user)
+  }
+
+  let(:needs_qa_ephemera_folder) {
+    FactoryGirl.create(:needs_qa_ephemera_folder, user: creating_user)
+  }
+
   let(:ephemera_editor_file) { FactoryGirl.build(:file_set, user: ephemera_editor) }
   let(:image_editor_file) { FactoryGirl.build(:file_set, user: image_editor) }
   let(:admin_file) { FactoryGirl.build(:file_set, user: admin_user) }
@@ -71,7 +79,7 @@ describe Ability do
     allow(image_editor_file).to receive(:id).and_return("image_editor_file")
     allow(ephemera_editor_file).to receive(:id).and_return("ephemera_editor_file")
     allow(admin_file).to receive(:id).and_return("admin_file")
-    [open_scanned_resource, private_scanned_resource, campus_only_scanned_resource, pending_scanned_resource, metadata_review_scanned_resource, final_review_scanned_resource, complete_scanned_resource, takedown_scanned_resource, flagged_scanned_resource, image_editor_file, ephemera_editor_file, admin_file].each do |obj|
+    [open_scanned_resource, private_scanned_resource, campus_only_scanned_resource, pending_scanned_resource, metadata_review_scanned_resource, final_review_scanned_resource, complete_scanned_resource, takedown_scanned_resource, flagged_scanned_resource, image_editor_file, ephemera_editor_file, admin_file, complete_ephemera_folder, needs_qa_ephemera_folder].each do |obj|
       allow(subject.cache).to receive(:get).with(obj.id).and_return(Hydra::PermissionsSolrDocument.new(obj.to_solr, nil))
     end
   end
@@ -349,6 +357,9 @@ describe Ability do
       should_not be_able_to(:destroy, role)
       should_not be_able_to(:complete, pending_scanned_resource)
       should_not be_able_to(:destroy, admin_file)
+
+      should_not be_able_to(:manifest, needs_qa_ephemera_folder)
+      should be_able_to(:manifest, complete_ephemera_folder)
     }
     it "cannot create works" do
       expect(subject.can_create_any_work?).to be false

--- a/spec/factories/ephemera_folder.rb
+++ b/spec/factories/ephemera_folder.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     folder_number [3]
     identifier ["32101091980639"]
     rights_statement ["http://rightsstatements.org/vocab/NKC/1.0/"]
+    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
 
     transient do
       user { FactoryGirl.create(:user) }
@@ -11,6 +12,20 @@ FactoryGirl.define do
 
     after(:build) do |work, evaluator|
       work.apply_depositor_metadata(evaluator.user.user_key)
+    end
+
+    factory :complete_ephemera_folder do
+      after(:create) do |work, evaluator|
+        FactoryGirl.create(:complete_sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+        work.save
+      end
+    end
+
+    factory :needs_qa_ephemera_folder do
+      after(:create) do |work, evaluator|
+        FactoryGirl.create(:needs_qa_sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+        work.save
+      end
     end
   end
 end

--- a/spec/factories/sipity_entities.rb
+++ b/spec/factories/sipity_entities.rb
@@ -8,6 +8,10 @@ FactoryGirl.define do
       association :workflow_state, factory: :workflow_state, name: 'pending'
     end
 
+    factory :needs_qa_sipity_entity, class: Sipity::Entity do
+      association :workflow_state, factory: :workflow_state, name: 'needs_qa'
+    end
+
     factory :flagged_sipity_entity, class: Sipity::Entity do
       association :workflow_state, factory: :workflow_state, name: 'flagged'
     end

--- a/spec/presenters/ephemera_folder_presenter_spec.rb
+++ b/spec/presenters/ephemera_folder_presenter_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe EphemeraFolderPresenter do
     end
 
     it "renders title as a regular attribute" do
-      expect(subject.renderer_for(:title, {})).to be Hyrax::Renderers::AttributeRenderer
+      expect(subject.renderer_for(:title, {})).to be ::AttributeRenderer
     end
   end
 end

--- a/spec/presenters/state_badge_spec.rb
+++ b/spec/presenters/state_badge_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe StateBadge do
     end
   end
 
+  describe "needs_qa" do
+    let(:scanned_resource) { FactoryGirl.create(:needs_qa_ephemera_folder) }
+
+    it "renders a badge" do
+      expect(subject.render).to include("label-info")
+      expect(subject.render).to include("Needs QA")
+    end
+  end
+
   describe "metadata_review" do
     let(:scanned_resource) { FactoryGirl.create(:metadata_review_scanned_resource) }
 

--- a/spec/services/workflow/plum_workflow_strategy_spec.rb
+++ b/spec/services/workflow/plum_workflow_strategy_spec.rb
@@ -20,4 +20,14 @@ RSpec.describe Workflow::PlumWorkflowStrategy, :no_clean, :admin_set do
       it { is_expected.to eq Sipity::Workflow.where(name: 'geo_works').first! }
     end
   end
+
+  context "when working with an ephemera folder" do
+    let(:work) { FactoryGirl.build(:ephemera_folder) }
+    let(:workflow_strategy) { described_class.new(work) }
+
+    describe "#workflow" do
+      subject { workflow_strategy.workflow }
+      it { is_expected.to eq Sipity::Workflow.where(name: 'folder_works').first! }
+    end
+  end
 end

--- a/spec/views/hyrax/base/_representative_media.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_representative_media.html.erb_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 RSpec.describe "hyrax/base/_representative_media.html.erb" do
   let(:presenter) { instance_double(ScannedResourceShowPresenter, member_presenters: member_presenters, id: "1", persisted?: true, model_name: ScannedResource.model_name) }
   let(:member_presenters) { [] }
+  let(:can_manifest) { true }
   before do
     allow(presenter).to receive(:to_model).and_return(presenter)
+    allow(view).to receive(:can?).with(:manifest, presenter).and_return(can_manifest)
     render partial: "hyrax/base/representative_media", locals: { presenter: presenter }
   end
   context "when there are no generic files" do
@@ -16,6 +18,12 @@ RSpec.describe "hyrax/base/_representative_media.html.erb" do
     let(:member_presenters) { [1] }
     it "renders the viewer" do
       expect(response).to have_selector ".viewer[data-uri]"
+    end
+    context "and the user doesn't have permission to manifest" do
+      let(:can_manifest) { false }
+      it "doesn't render the viewer" do
+        expect(response).to have_selector "img[src='/assets/nope.png']"
+      end
     end
   end
 end


### PR DESCRIPTION
1. Adds a two-step workflow for Ephemera Folders. Immediately upon
ingest the metadata record is public, but the manifest is locked down.

2. When QA of images is complete, the manifest is made public.

3. Ephemera Editors can back out the workflow from Complete -> Needs QA.

This PR also fixes attribute display of rights/state for Ephemera
Folders.