### PR TITLE
Force coverage to be single valued in geo works

### DIFF
--- a/app/forms/hyrax/geo_work_form.rb
+++ b/app/forms/hyrax/geo_work_form.rb
@@ -31,5 +31,12 @@ module Hyrax
       return false if ['rights_statement'].include?(field.to_s)
       super
     end
+
+    def self.multiple?(field)
+      # Necessary to permit coverage param. Coverage is declared as
+      # single-valued in GeoWorks. We'll keep it that way for now.
+      return false if field.to_sym == :coverage
+      super
+    end
   end
 end

--- a/spec/controllers/hyrax/map_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/map_sets_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Hyrax::MapSetsController do
   let(:user) { FactoryGirl.create(:user) }
   let(:coverage) { GeoWorks::Coverage.new(43.039, -69.856, 42.943, -71.032).to_s }
   let(:map_set) { FactoryGirl.create(:map_set, user: user, title: ['Dummy Title'], coverage: coverage) }
+  let(:reloaded) { map_set.reload }
 
   describe 'create' do
     let(:user) { FactoryGirl.create(:admin) }
@@ -23,6 +24,19 @@ RSpec.describe Hyrax::MapSetsController do
         expect(s.title.first.to_s).to eq 'Netherlands, Nieuwe Waterweg and Europoort : Hoek Van Holland to Vlaardingen'
         expect(s.coverage).to eq 'northlimit=52.024167; eastlimit=004.341667; southlimit=51.920000; westlimit=003.966667; units=degrees; projection=EPSG:4326'
       end
+    end
+  end
+
+  describe 'update' do
+    let(:map_set) { FactoryGirl.create(:map_set, user: user, title: ['Dummy Title']) }
+
+    before do
+      sign_in user
+    end
+
+    it 'can update the coverage' do
+      post :update, params: { id: map_set, map_set: { coverage: coverage } }
+      expect(reloaded.coverage).to eq coverage
     end
   end
 


### PR DESCRIPTION
Fixes issue where coverage is not editable. Closes #1295 