### PR TITLE
Add geo_file_set_presenters methods to MapSet presenter

### DIFF
--- a/app/presenters/map_set_show_presenter.rb
+++ b/app/presenters/map_set_show_presenter.rb
@@ -2,6 +2,11 @@ class MapSetShowPresenter < HyraxShowPresenter
   include PlumAttributes
   delegate :spatial, :temporal, :issued, :coverage, :provenance, :layer_modified, to: :solr_document
 
+  # MapSets done't contain geo file sets directly
+  def geo_file_set_presenters
+    nil
+  end
+
   def external_metadata_file_set_presenters
     # filter for external metadata files
     file_set_presenters.select do |member|

--- a/app/services/discovery/document_path.rb
+++ b/app/services/discovery/document_path.rb
@@ -34,12 +34,5 @@ module Discovery
         path = hyrax_url_helpers.download_url(id, host: host, protocol: protocol)
         "#{path}?file=thumbnail"
       end
-
-      # Override method for MapSets. MapSets don't contain image files directly.
-      def file_set
-        return if map_set?
-        return unless geo_concern.geo_file_set_presenters
-        geo_concern.geo_file_set_presenters.first
-      end
   end
 end


### PR DESCRIPTION
Fixes issue where geoblacklight documents are not generated for MapSets because of logic in GeoWorks.