### PR TITLE
MapSet geo_file_set_presenters method should return an empty array

### DIFF
--- a/app/presenters/map_set_show_presenter.rb
+++ b/app/presenters/map_set_show_presenter.rb
@@ -4,7 +4,7 @@ class MapSetShowPresenter < HyraxShowPresenter
 
   # MapSets done't contain geo file sets directly
   def geo_file_set_presenters
-    nil
+    []
   end
 
   def external_metadata_file_set_presenters


### PR DESCRIPTION
MapSet Presenter `geo_file_set_presenters` method should return an empty array instead of nil. Fixes (yet another) issue with geoblacklight document generation.
