### PR TITLE
Add dct_source and suppressed fields to geoblacklight solr document

### DIFF
--- a/app/services/discovery/geoblacklight_document.rb
+++ b/app/services/discovery/geoblacklight_document.rb
@@ -1,6 +1,6 @@
 module Discovery
   class GeoblacklightDocument < GeoWorks::Discovery::GeoblacklightDocument
-    attr_accessor :iiif, :iiif_manifest
+    attr_accessor :iiif, :iiif_manifest, :source, :suppressed
 
     def to_hash(_args = nil)
       return document unless access_rights == private_visibility
@@ -11,6 +11,18 @@ module Discovery
     def to_json(_args = nil)
       return document.to_json unless access_rights == private_visibility
       private_document.to_json
+    end
+
+    # Override to add extra key value pairs to document
+    def document_hash_optional
+      super.merge(document_hash_plum)
+    end
+
+    def document_hash_plum
+      {
+        suppressed_b: suppressed,
+        dct_source_sm: source
+      }
     end
 
     # Overrides references to add iiif ref

--- a/app/services/discovery/relationship_builder.rb
+++ b/app/services/discovery/relationship_builder.rb
@@ -1,0 +1,42 @@
+module Discovery
+  class RelationshipBuilder
+    attr_reader :geo_work
+
+    def initialize(geo_work)
+      @geo_work = geo_work
+    end
+
+    def build(document)
+      document.source = source
+      document.suppressed = suppressed
+    end
+
+    private
+
+      def source
+        return unless image_work? && parent?
+        parents
+      end
+
+      def suppressed
+        return unless image_work? && parent?
+        true
+      end
+
+      def image_work?
+        geo_work.model_name.to_s == 'ImageWork'
+      end
+
+      def parent?
+        geo_work.member_of_ids.count > 0
+      end
+
+      def parents
+        geo_work.member_of_ids.map do |id|
+          map_set = MapSet.search_with_conditions(id: id).first
+          map_set_presenter = MapSetShowPresenter.new(SolrDocument.new(map_set), nil)
+          Discovery::SlugBuilder.new(map_set_presenter).slug
+        end
+      end
+  end
+end

--- a/config/initializers/plum_config.rb
+++ b/config/initializers/plum_config.rb
@@ -32,7 +32,8 @@ GeoWorks::Discovery::DocumentBuilder.services = [
   Discovery::LayerInfoBuilder,
   Discovery::SlugBuilder,
   Discovery::IIIFBuilder,
-  Discovery::WxsBuilder
+  Discovery::WxsBuilder,
+  Discovery::RelationshipBuilder
 ]
 
 GeoWorks::EventsGenerator.services = [

--- a/spec/services/discovery/geoblacklight_document_spec.rb
+++ b/spec/services/discovery/geoblacklight_document_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Discovery::GeoblacklightDocument do
 
     context 'with a public image work with a mapset parent' do
       let(:identifier) { ['ark:/99999/fk44jq866'] }
-      let(:map_set) { FactoryGirl.build(:map_set_with_image_work, id: 'map-set-1', identifier: identifier) }
+      let(:map_set) { FactoryGirl.build(:map_set_with_image_work, identifier: identifier) }
       let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
 
       before do
@@ -102,6 +102,15 @@ RSpec.describe Discovery::GeoblacklightDocument do
       it 'returns a suppressed document with a source field' do
         expect(document[:suppressed_b]).to eq true
         expect(document[:dct_source_sm]).to eq ['princeton-fk44jq866']
+      end
+
+      context 'with the parent map set' do
+        let(:geo_concern_presenter) { MapSetShowPresenter.new(SolrDocument.new(map_set.to_solr), nil) }
+
+        it 'does not return a suppressed document or a source field' do
+          expect(document[:suppressed_b]).to be_nil
+          expect(document[:dct_source_sm]).to be_nil
+        end
       end
     end
   end

--- a/spec/services/discovery/geoblacklight_document_spec.rb
+++ b/spec/services/discovery/geoblacklight_document_spec.rb
@@ -87,6 +87,23 @@ RSpec.describe Discovery::GeoblacklightDocument do
         expect(document[:dc_rights_s]).to eq 'Public'
       end
     end
+
+    context 'with a public image work with a mapset parent' do
+      let(:identifier) { ['ark:/99999/fk44jq866'] }
+      let(:map_set) { FactoryGirl.build(:map_set_with_image_work, id: 'map-set-1', identifier: identifier) }
+      let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+
+      before do
+        map_set.ordered_members << geo_concern
+        map_set.save
+        geo_concern.update_index
+      end
+
+      it 'returns a suppressed document with a source field' do
+        expect(document[:suppressed_b]).to eq true
+        expect(document[:dct_source_sm]).to eq ['princeton-fk44jq866']
+      end
+    end
   end
 
   describe 'references' do


### PR DESCRIPTION
Adds `dct_source_sm` and `suppressed_b` to Image Work geoblacklight documents. Closes #1320 