### PR TITLE
Memoize messaging clients

### DIFF
--- a/config/initializers/plum_config.rb
+++ b/config/initializers/plum_config.rb
@@ -4,11 +4,11 @@ module Plum
   end
 
   def messaging_client
-    MessagingClient.new(Plum.config['events']['server'])
+    @messaging_client ||= MessagingClient.new(Plum.config['events']['server'])
   end
 
   def geoblacklight_messaging_client
-    GeoblacklightMessagingClient.new(Plum.config['events']['server'])
+    @geoblacklight_messaging_client ||= GeoblacklightMessagingClient.new(Plum.config['events']['server'])
   end
 
   private

--- a/spec/services/geo_works/trigger_update_events_spec.rb
+++ b/spec/services/geo_works/trigger_update_events_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe GeoWorks::TriggerUpdateEvents do
   let(:messaging_client) { instance_double(GeoblacklightMessagingClient) }
 
   before do
-    allow(GeoblacklightMessagingClient).to receive(:new).and_return(messaging_client)
+    allow(Plum).to receive(:geoblacklight_messaging_client).and_return(messaging_client)
   end
 
   describe '#call' do


### PR DESCRIPTION
I think this might solve the problem with multiple RabbitMQ connections. The messaging clients are initialized only once during startup. @tpendragon does this seem right to you?

Closes #1349 