### PR TITLE
EphemeraFolder form cleanup

### DIFF
--- a/app/forms/hyrax/ephemera_folder_form.rb
+++ b/app/forms/hyrax/ephemera_folder_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   class EphemeraFolderForm < ::Hyrax::Forms::WorkForm
     include SingleValuedForm
     self.model_class = ::EphemeraFolder
-    self.terms = [:barcode, :folder_number, :title, :sort_title, :alternative_title, :language, :genre, :width, :height, :page_count, :box_id, :rights_statement, :series, :creator, :contributor, :publisher, :geographic_origin, :subject, :geo_subject, :description, :date_created, :member_of_collection_ids, :visibility]
+    self.terms = [:barcode, :folder_number, :title, :sort_title, :alternative_title, :language, :genre, :width, :height, :page_count, :box_id, :rights_statement, :series, :creator, :contributor, :publisher, :geographic_origin, :subject, :geo_subject, :description, :date_created, :member_of_collection_ids]
     self.required_fields = [:title, :barcode, :folder_number, :width, :height, :page_count, :box_id, :language, :genre, :rights_statement]
     self.single_valued_fields = [:title, :sort_title, :creator, :geographic_origin, :date_created, :genre, :description, :barcode, :folder_number, :genre, :width, :height, :page_count, :rights_statement]
     delegate :box_id, :project, to: :model

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -44,7 +44,12 @@ en:
   simple_form:
     hints:
       defaults:
+        description: 'Free-text notes about the work.'
         files: ''
+        publisher: 'The person or group making the work available.'
+        subject: 'Terms describing what the work is about.'
+        title: ''
     labels:
       defaults:
         alternative: 'Alternative title'
+        description: 'Description'


### PR DESCRIPTION
Cleaning up the EphemeraFolder form:

* changing label for description
* removing or editing hints for description, publisher, subject and title
* removing spurious visibility field at bottom of the form

Fixes #1301 