### PR TITLE
Caching and Performance Improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'rsolr', '~> 1.1.0'
 gem 'devise' , '~> 4.2.0'
 gem 'devise-guests', '~> 0.3'
 gem 'iiif-presentation', github: 'iiif/osullivan', branch: 'development'
-gem 'geo_works', '~> 0.1.2'
+gem 'geo_works', '~> 0.1.3'
 
 # PDF generation
 gem 'prawn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,7 +330,7 @@ GEM
       jquery-rails
     font-awesome-rails (4.7.0.1)
       railties (>= 3.2, < 5.1)
-    geo_works (0.1.2)
+    geo_works (0.1.3)
       hyrax (>= 1.0.1, < 2.0)
       jquery-ui-rails (~> 5.0.5)
       json-schema (>= 2.6.2)
@@ -899,7 +899,7 @@ DEPENDENCIES
   factory_girl
   fcrepo_wrapper (~> 0.8.0)
   flipflop!
-  geo_works (~> 0.1.2)
+  geo_works (~> 0.1.3)
   grocer!
   honeybadger (~> 2.0)
   hydra-derivatives (= 3.1.3)

--- a/app/controllers/hyrax/geo_works_controller.rb
+++ b/app/controllers/hyrax/geo_works_controller.rb
@@ -4,6 +4,14 @@ class Hyrax::GeoWorksController < ApplicationController
   include GeoWorks::GeoblacklightControllerBehavior
   include Hyrax::GeoEventsBehavior
 
+  def geoblacklight
+    respond_to do |f|
+      f.json do
+        render json: builder
+      end
+    end
+  end
+
   private
 
     def decorator
@@ -19,5 +27,11 @@ class Hyrax::GeoWorksController < ApplicationController
         begin
           @curation_concern = decorator.new(@curation_concern)
         end
+    end
+
+    def builder
+      Rails.cache.fetch("geoblacklight/#{presenter.id}/#{ResourceIdentifier.new(presenter.id)}") do
+        GeoWorks::Discovery::DocumentBuilder.new(presenter, document_class.new).to_json
+      end
     end
 end

--- a/app/services/discovery/document_path.rb
+++ b/app/services/discovery/document_path.rb
@@ -19,7 +19,7 @@ module Discovery
     end
 
     def default_url_options
-      ActionMailer::Base.default_url_options
+      Plum.default_url_options
     end
 
     private

--- a/app/services/manifest_builder/hyrax_manifest_helper.rb
+++ b/app/services/manifest_builder/hyrax_manifest_helper.rb
@@ -4,7 +4,7 @@ class ManifestBuilder
     include ActionDispatch::Routing::PolymorphicRoutes
 
     def default_url_options
-      ActionMailer::Base.default_url_options
+      Plum.default_url_options
     end
   end
 end

--- a/app/services/manifest_builder/manifest_helper.rb
+++ b/app/services/manifest_builder/manifest_helper.rb
@@ -4,7 +4,7 @@ class ManifestBuilder
     include Rails.application.routes.url_helpers
 
     def default_url_options
-      ActionMailer::Base.default_url_options
+      Plum.default_url_options
     end
   end
 end

--- a/config/initializers/plum_config.rb
+++ b/config/initializers/plum_config.rb
@@ -11,13 +11,17 @@ module Plum
     @geoblacklight_messaging_client ||= GeoblacklightMessagingClient.new(Plum.config['events']['server'])
   end
 
+  def default_url_options
+    @default_url_options ||= ActionMailer::Base.default_url_options
+  end
+
   private
 
     def config_yaml
       YAML.load(ERB.new(File.read("#{Rails.root}/config/config.yml")).result)[Rails.env]
     end
 
-    module_function :config, :config_yaml, :messaging_client, :geoblacklight_messaging_client
+    module_function :config, :config_yaml, :messaging_client, :geoblacklight_messaging_client, :default_url_options
 end
 
 Hydra::Derivatives.kdu_compress_recipes = Plum.config['jp2_recipes']


### PR DESCRIPTION
- Caches geoblacklight documents.
- Stores `default_url_options` in Plum config. Profiling shows that calls to `ActionMailer::Base.default_url_options` are the single slowest step in generating documents.
- Uses GeoWorks 0.1.3 which includes several performance enhancements.

Closes #1347 