### PR TITLE
Add a new workflow for Boxes

### DIFF
--- a/app/forms/hyrax/ephemera_box_form.rb
+++ b/app/forms/hyrax/ephemera_box_form.rb
@@ -4,12 +4,16 @@ module Hyrax
   class EphemeraBoxForm < ::Hyrax::Forms::WorkForm
     include SingleValuedForm
     self.model_class = ::EphemeraBox
-    self.terms = [:barcode, :box_number, :member_of_collection_ids, :ephemera_project_id]
+    self.terms = [:barcode, :box_number, :member_of_collection_ids, :ephemera_project_id, :shipped_date, :tracking_number]
     self.required_fields = [:barcode, :box_number, :ephemera_project_id]
-    self.single_valued_fields = [:barcode, :box_number, :ephemera_project_id]
+    self.single_valued_fields = [:barcode, :box_number, :ephemera_project_id, :shipped_date, :tracking_number]
 
     def autofocus_barcode?
       true
+    end
+
+    def primary_terms
+      super + [:shipped_date, :tracking_number]
     end
   end
 end

--- a/app/forms/hyrax/ephemera_folder_form.rb
+++ b/app/forms/hyrax/ephemera_folder_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   class EphemeraFolderForm < ::Hyrax::Forms::WorkForm
     include SingleValuedForm
     self.model_class = ::EphemeraFolder
-    self.terms = [:barcode, :folder_number, :title, :sort_title, :alternative_title, :language, :genre, :width, :height, :page_count, :box_id, :rights_statement, :series, :creator, :contributor, :publisher, :geographic_origin, :subject, :geo_subject, :description, :date_created, :member_of_collection_ids]
+    self.terms = [:barcode, :folder_number, :title, :sort_title, :alternative_title, :language, :genre, :width, :height, :page_count, :box_id, :rights_statement, :series, :creator, :contributor, :publisher, :geographic_origin, :subject, :geo_subject, :description, :date_created, :member_of_collection_ids, :visibility]
     self.required_fields = [:title, :barcode, :folder_number, :width, :height, :page_count, :box_id, :language, :genre, :rights_statement]
     self.single_valued_fields = [:title, :sort_title, :creator, :geographic_origin, :date_created, :genre, :description, :barcode, :folder_number, :genre, :width, :height, :page_count, :rights_statement]
     delegate :box_id, :project, to: :model
@@ -22,7 +22,7 @@ module Hyrax
     end
 
     def primary_terms
-      terms - [:member_of_collection_ids]
+      terms - [:member_of_collection_ids, :visibility]
     end
 
     def secondary_terms

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -153,6 +153,9 @@ class Ability
       readable_concern?(curation_concern)
     end
     cannot [:manifest], EphemeraFolder do |folder|
+      folder.workflow_state == "needs_qa" && !folder.member_of_collections.map(&:workflow_state).include?("all_in_production")
+    end
+    cannot [:manifest], EphemeraFolderPresenter do |folder|
       folder.workflow_state == "needs_qa"
     end
     can :pdf, (curation_concerns + [ScannedResourceShowPresenter]) do |curation_concern|

--- a/app/models/ephemera_box.rb
+++ b/app/models/ephemera_box.rb
@@ -13,6 +13,8 @@ class EphemeraBox < ActiveFedora::Base
   property :barcode, predicate: ::PULTerms.barcode
   property :box_number, predicate: ::RDF::RDFS.label
   property :ephemera_project, predicate: ::PULTerms.ephemera_project
+  property :shipped_date, predicate: ::PULTerms.shipped_date
+  property :tracking_number, predicate: ::PULTerms.tracking_number
 
   self.human_readable_type = 'Ephemera Box'
   def box_number=(title)

--- a/app/models/vocab/pul_terms.rb
+++ b/app/models/vocab/pul_terms.rb
@@ -11,4 +11,6 @@ class PULTerms < RDF::StrictVocabulary('http://library.princeton.edu/terms/')
   term :seriesTitle, label: 'Series Title'.freeze, type: 'rdf:Property'.freeze
   term :barcode, label: 'Barcode'.freeze, type: 'rdf:Property'.freeze
   term :ephemera_project, label: 'Ephemera Project'.freeze, type: 'rdf:Property'.freeze
+  term :shipped_date, label: 'Shipped Date'.freeze, type: 'rdf:Property'.freeze
+  term :tracking_number, label: 'Tracking Number'.freeze, type: 'rdf:Property'.freeze
 end

--- a/app/presenters/ephemera_box_presenter.rb
+++ b/app/presenters/ephemera_box_presenter.rb
@@ -1,4 +1,5 @@
 class EphemeraBoxPresenter < HyraxShowPresenter
+  include PlumAttributes
   delegate :barcode, :ephemera_project_id, :ephemera_project_name, :ephemera_project_name, to: :solr_document
   def member_presenters
     @member_presenters ||= Hyrax::PresenterFactory.build_presenters(member_ids,

--- a/app/presenters/state_badge.rb
+++ b/app/presenters/state_badge.rb
@@ -52,7 +52,11 @@ class StateBadge
         final_review: 'label-primary',
         complete: 'label-success',
         flagged: 'label-warning',
-        takedown: 'label-danger'
+        takedown: 'label-danger',
+        ready_to_ship: 'label-info',
+        shipped: 'label-info',
+        received: 'label-default',
+        all_in_production: 'label-success'
       }
     end
 

--- a/app/services/workflow/plum_workflow_strategy.rb
+++ b/app/services/workflow/plum_workflow_strategy.rb
@@ -10,6 +10,7 @@ module Workflow
     def workflow
       return Sipity::Workflow.where(name: 'book_works').first! if book_works.include? work_class
       return Sipity::Workflow.where(name: 'folder_works').first! if folder_works.include? work_class
+      return Sipity::Workflow.where(name: 'ephemera_box_works').first! if box_works.include? work_class
       return Sipity::Workflow.where(name: 'geo_works').first! if geo_works.include? work_class
     end
 
@@ -20,7 +21,11 @@ module Workflow
       end
 
       def book_works
-        %w(ScannedResource MultiVolumeWork EphemeraBox)
+        %w(ScannedResource MultiVolumeWork)
+      end
+
+      def box_works
+        %w(EphemeraBox)
       end
 
       def folder_works

--- a/app/views/records/edit_fields/_shipped_date.html.erb
+++ b/app/views/records/edit_fields/_shipped_date.html.erb
@@ -1,0 +1,1 @@
+<%= f.input :shipped_date, input_html: { class: 'timepicker' }, required: f.object.required?(:shipped_date) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,3 +66,15 @@ en:
     takedown:
       label: 'Takedown'
       desc:  'Formerly-published but suppressed from display'
+    ready_to_ship:
+      label: 'Ready to Ship'
+      desc: 'Ready to ship.'
+    shipped:
+      label: 'Shipped'
+      desc: 'Shipped'
+    received:
+      label: 'Received'
+      desc: 'Received'
+    all_in_production:
+      label: 'All in Production'
+      desc: 'Mark all contained folders as having received QA, and put them into the public display.'

--- a/config/workflows/box_workflow.json
+++ b/config/workflows/box_workflow.json
@@ -1,0 +1,79 @@
+{
+  "workflows": [
+    {
+      "name": "ephemera_box_works",
+      "label": "Ephemera Box Works",
+      "actions": [
+        {
+          "name": "new",
+          "from_states": [],
+          "transition_to": "new",
+          "methods": [
+            "Workflow::Folders::GrantEditToGroups",
+            "Hyrax::Workflow::ActivateObject"
+          ]
+        },
+        {
+          "name": "ready_to_ship",
+          "from_states": [
+            {
+              "names": ["new"],
+              "roles": [
+                "admin",
+                "ephemera_editor"
+              ]
+            }
+          ],
+          "transition_to": "ready_to_ship",
+          "methods": [],
+          "notifications": []
+        },
+        {
+          "name": "shipped",
+          "from_states": [
+            {
+              "names": ["ready_to_ship"],
+              "roles": [
+                "admin",
+                "ephemera_editor"
+              ]
+            }
+          ],
+          "transition_to": "shipped",
+          "methods": [],
+          "notifications": []
+        },
+        {
+          "name": "received",
+          "from_states": [
+            {
+              "names": ["shipped"],
+              "roles": [
+                "admin",
+                "ephemera_editor"
+              ]
+            }
+          ],
+          "transition_to": "received",
+          "methods": [],
+          "notifications": []
+        },
+        {
+          "name": "all_in_production",
+          "from_states": [
+            {
+              "names": ["received"],
+              "roles": [
+                "admin",
+                "ephemera_editor"
+              ]
+            }
+          ],
+          "methods": [],
+          "transition_to": "all_in_production",
+          "notifications": []
+        }
+      ]
+    }
+  ]
+}

--- a/spec/ability/roles_spec.rb
+++ b/spec/ability/roles_spec.rb
@@ -52,6 +52,11 @@ describe Ability do
     FactoryGirl.create(:needs_qa_ephemera_folder, user: creating_user)
   }
 
+  let(:ephemera_folder_in_all_complete_box) {
+    box = FactoryGirl.create(:all_in_production_box)
+    FactoryGirl.create(:needs_qa_ephemera_folder, user: creating_user, member_of_collections: [box])
+  }
+
   let(:external_metadata_file) { FactoryGirl.build(:file_set, user: creating_user, geo_mime_type: 'application/xml; schema=fgdc') }
   let(:ephemera_editor_file) { FactoryGirl.build(:file_set, user: ephemera_editor) }
   let(:image_editor_file) { FactoryGirl.build(:file_set, user: image_editor) }
@@ -85,7 +90,7 @@ describe Ability do
     allow(image_editor_file).to receive(:id).and_return("image_editor_file")
     allow(ephemera_editor_file).to receive(:id).and_return("ephemera_editor_file")
     allow(admin_file).to receive(:id).and_return("admin_file")
-    [open_scanned_resource, private_scanned_resource, campus_only_scanned_resource, pending_scanned_resource, metadata_review_scanned_resource, final_review_scanned_resource, complete_scanned_resource, takedown_scanned_resource, flagged_scanned_resource, image_editor_file, ephemera_editor_file, admin_file, complete_ephemera_folder, needs_qa_ephemera_folder].each do |obj|
+    [open_scanned_resource, private_scanned_resource, campus_only_scanned_resource, pending_scanned_resource, metadata_review_scanned_resource, final_review_scanned_resource, complete_scanned_resource, takedown_scanned_resource, flagged_scanned_resource, image_editor_file, ephemera_editor_file, admin_file, complete_ephemera_folder, needs_qa_ephemera_folder, ephemera_folder_in_all_complete_box].each do |obj|
       allow(subject.cache).to receive(:get).with(obj.id).and_return(Hydra::PermissionsSolrDocument.new(obj.to_solr, nil))
     end
   end
@@ -169,6 +174,7 @@ describe Ability do
 
       should be_able_to(:manifest, presenter(complete_ephemera_folder))
       should be_able_to(:manifest, presenter(needs_qa_ephemera_folder))
+      should be_able_to(:manifest, presenter(ephemera_folder_in_all_complete_box))
 
       should_not be_able_to(:create, Role.new)
       should_not be_able_to(:destroy, role)
@@ -376,6 +382,8 @@ describe Ability do
       should_not be_able_to(:destroy, admin_file)
 
       should_not be_able_to(:manifest, needs_qa_ephemera_folder)
+      should_not be_able_to(:manifest, presenter(needs_qa_ephemera_folder))
+      should be_able_to(:manifest, ephemera_folder_in_all_complete_box)
       should be_able_to(:manifest, complete_ephemera_folder)
     }
     it "cannot create works" do

--- a/spec/factories/ephemera_box.rb
+++ b/spec/factories/ephemera_box.rb
@@ -2,5 +2,29 @@ FactoryGirl.define do
   factory :ephemera_box do
     box_number [3]
     barcode ["32101091980639"]
+    factory :ready_to_ship_box do
+      after(:create) do |work, evaluator|
+        FactoryGirl.create(:ready_to_ship_sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+        work.save
+      end
+    end
+    factory :shipped_box do
+      after(:create) do |work, evaluator|
+        FactoryGirl.create(:shipped_sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+        work.save
+      end
+    end
+    factory :received_box do
+      after(:create) do |work, evaluator|
+        FactoryGirl.create(:received_sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+        work.save
+      end
+    end
+    factory :all_in_production_box do
+      after(:create) do |work, evaluator|
+        FactoryGirl.create(:all_in_production_sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+        work.save
+      end
+    end
   end
 end

--- a/spec/factories/sipity_entities.rb
+++ b/spec/factories/sipity_entities.rb
@@ -12,6 +12,22 @@ FactoryGirl.define do
       association :workflow_state, factory: :workflow_state, name: 'needs_qa'
     end
 
+    factory :ready_to_ship_sipity_entity, class: Sipity::Entity do
+      association :workflow_state, factory: :workflow_state, name: 'ready_to_ship'
+    end
+
+    factory :shipped_sipity_entity, class: Sipity::Entity do
+      association :workflow_state, factory: :workflow_state, name: 'shipped'
+    end
+
+    factory :received_sipity_entity, class: Sipity::Entity do
+      association :workflow_state, factory: :workflow_state, name: 'received'
+    end
+
+    factory :all_in_production_sipity_entity, class: Sipity::Entity do
+      association :workflow_state, factory: :workflow_state, name: 'all_in_production'
+    end
+
     factory :flagged_sipity_entity, class: Sipity::Entity do
       association :workflow_state, factory: :workflow_state, name: 'flagged'
     end

--- a/spec/forms/hyrax/ephemera_box_form_spec.rb
+++ b/spec/forms/hyrax/ephemera_box_form_spec.rb
@@ -7,4 +7,10 @@ RSpec.describe Hyrax::EphemeraBoxForm do
   it "wants barcode autofocus" do
     expect(subject.autofocus_barcode?).to be true
   end
+
+  describe "#primary_terms" do
+    it "has primary terms" do
+      expect(subject.primary_terms).to include :shipped_date, :tracking_number
+    end
+  end
 end

--- a/spec/forms/hyrax/ephemera_folder_form_spec.rb
+++ b/spec/forms/hyrax/ephemera_folder_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hyrax::EphemeraFolderForm do
 
   describe "#primary_terms" do
     it "has primary terms" do
-      expect(form.primary_terms).to eq(form.terms - [:member_of_collection_ids])
+      expect(form.primary_terms).to eq(form.terms - [:member_of_collection_ids, :visibility])
     end
   end
 

--- a/spec/presenters/state_badge_spec.rb
+++ b/spec/presenters/state_badge_spec.rb
@@ -22,6 +22,42 @@ RSpec.describe StateBadge do
     end
   end
 
+  describe "ready_to_ship" do
+    let(:scanned_resource) { FactoryGirl.create(:ready_to_ship_box) }
+
+    it "renders a badge" do
+      expect(subject.render).to include("label-info")
+      expect(subject.render).to include("Ready to Ship")
+    end
+  end
+
+  describe "shipped" do
+    let(:scanned_resource) { FactoryGirl.create(:shipped_box) }
+
+    it "renders a badge" do
+      expect(subject.render).to include("label-info")
+      expect(subject.render).to include("Shipped")
+    end
+  end
+
+  describe "received" do
+    let(:scanned_resource) { FactoryGirl.create(:received_box) }
+
+    it "renders a badge" do
+      expect(subject.render).to include("label-default")
+      expect(subject.render).to include("Received")
+    end
+  end
+
+  describe "all_in_production" do
+    let(:scanned_resource) { FactoryGirl.create(:all_in_production_box) }
+
+    it "renders a badge" do
+      expect(subject.render).to include("label-success")
+      expect(subject.render).to include("All in Production")
+    end
+  end
+
   describe "metadata_review" do
     let(:scanned_resource) { FactoryGirl.create(:metadata_review_scanned_resource) }
 

--- a/spec/services/workflow/plum_workflow_strategy_spec.rb
+++ b/spec/services/workflow/plum_workflow_strategy_spec.rb
@@ -30,4 +30,14 @@ RSpec.describe Workflow::PlumWorkflowStrategy, :no_clean, :admin_set do
       it { is_expected.to eq Sipity::Workflow.where(name: 'folder_works').first! }
     end
   end
+
+  context "when working with an Ephemera box" do
+    let(:work) { FactoryGirl.build(:ephemera_box) }
+    let(:workflow_strategy) { described_class.new(work) }
+
+    describe "#workflow" do
+      subject { workflow_strategy.workflow }
+      it { is_expected.to eq Sipity::Workflow.where(name: 'ephemera_box_works').first! }
+    end
+  end
 end


### PR DESCRIPTION
This allows for boxes to be tracked through its shipping process, as
well as lets you assign at the box level whether the folders are
available for public viewing.

Closes #1376