### PR TITLE
[WIP] Overrides the DateBuilder Service for GeoWorks::Discovery::DocumentBuilder

### DIFF
--- a/app/presenters/plum_attributes.rb
+++ b/app/presenters/plum_attributes.rb
@@ -1,5 +1,5 @@
 module PlumAttributes
-  delegate :state, :type, :identifier, :thumbnail_id, :source_metadata_identifier, :collection, to: :solr_document
+  delegate :state, :type, :identifier, :thumbnail_id, :source_metadata_identifier, :collection, :date, to: :solr_document
 
   def state_badge
     state_badge_instance.render

--- a/app/services/discovery/date_builder.rb
+++ b/app/services/discovery/date_builder.rb
@@ -1,0 +1,21 @@
+module Discovery
+  class DateBuilder < GeoWorks::Discovery::DocumentBuilder::DateBuilder
+    private
+
+      # Overrides the date field parsing from GeoWorks
+      # Builds date fields such as layer year and modified date.
+      # Prefers the field parsed by GeoWorks, but defaults to <dc:date>
+      # @return [Integer] year
+      def layer_year
+        year = super
+        if year.blank?
+          date = geo_concern.date.first
+          year_m = date.match(/(?<=\D|^)(\d{4})(?=\D|$)/)
+          year = year_m ? year_m[0].to_i : nil
+        end
+        year
+      rescue
+        ''
+      end
+  end
+end

--- a/spec/services/discovery/date_builder_spec.rb
+++ b/spec/services/discovery/date_builder_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe Discovery::DateBuilder do
+  subject { described_class.new(geo_work_presenter) }
+
+  let(:document) { instance_double('Document') }
+  let(:geo_work_presenter) { VectorWorkShowPresenter.new(SolrDocument.new(geo_work.to_solr), nil) }
+
+  describe 'geospatial work document' do
+    before do
+      expect(document).to receive(:layer_modified=)
+      expect(document).to receive(:issued=)
+    end
+
+    context 'with temporal values' do
+      let(:geo_work) { FactoryGirl.build(:vector_work, temporal: ['1985']) }
+
+      it 'builds the layer year from the temporal attribute', date_builder: true do
+        expect(document).to receive(:layer_year=).with(1985)
+        subject.build(document)
+      end
+    end
+
+    context 'with date values' do
+      let(:geo_work) { FactoryGirl.build(:vector_work, date: ['1969']) }
+
+      it 'builds the layer year from the date attribute', date_builder: true do
+        expect(document).to receive(:layer_year=).with(1969)
+        subject.build(document)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #1401 by ensuring that layer years are parsed from the "date" attribute when "temporal" is empty