### PR TITLE
Overriding the "show" templates for RasterWorks and VectorWorks

### DIFF
--- a/app/views/hyrax/raster_works/_show_actions.html.erb
+++ b/app/views/hyrax/raster_works/_show_actions.html.erb
@@ -1,0 +1,19 @@
+<% if collector || editor %>
+  <div class="form-actions">
+    <% if editor %>
+      <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]), class: 'btn btn-default' %>
+      <div class="btn-group">
+        <button class="btn btn-default btn-small dropdown-toggle" data-toggle="dropdown" href="#"> Attach File <span class="caret"></span></button>
+        <ul class="dropdown-menu">
+          <li>
+            <%= link_to "Attach Raster", main_app.new_hyrax_file_set_path(@presenter, type: 'raster-data') %>
+          </li>
+          <li>
+            <%= link_to "Attach Metadata", main_app.new_hyrax_file_set_path(@presenter, type: 'metadata') %>
+          </li>
+        </ul>
+      </div>
+    <% end %>
+      <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
+  </div>
+<% end %>

--- a/app/views/hyrax/raster_works/show.html.erb
+++ b/app/views/hyrax/raster_works/show.html.erb
@@ -1,0 +1,23 @@
+<% provide :page_title, @presenter.page_title %>
+<% provide :page_header do %>
+  <%= render "hyrax/base/title_header" %>
+  <% if @parent_presenter %>
+    <ul class="breadcrumb">
+      <li><%= link_to @parent_presenter, polymorphic_path([main_app, @parent_presenter]) %></li>
+      <li class="active"><%= @presenter.human_readable_type %></li>
+    </ul>
+  <% else %>
+    <span class="human_readable_type">(<%= @presenter.human_readable_type %>)</span>
+  <% end %>
+<% end %>
+
+<% collector = can?(:collect, @presenter.id) %>
+<% editor    = can?(:edit,    @presenter.id) %>
+
+<%= render 'geo_works/representative_media', presenter: @presenter %>
+<%= render 'geo_works/metadata', presenter: @presenter %>
+<%= render 'geo_works/relationships', presenter: @presenter %>
+<%= render 'geo_works/related/geo_files', presenter: @presenter %>
+<%= render 'geo_works/related/external_metadata_files', presenter: @presenter %>
+<%= render 'workflow_actions', presenter: @presenter if @presenter.workflow.actions.present? %>
+<%= render "show_actions", collector: collector, editor: editor %>

--- a/app/views/hyrax/vector_works/_show_actions.html.erb
+++ b/app/views/hyrax/vector_works/_show_actions.html.erb
@@ -1,0 +1,19 @@
+<% if collector || editor %>
+  <div class="form-actions">
+    <% if editor %>
+      <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]), class: 'btn btn-default' %>
+      <div class="btn-group">
+        <button class="btn btn-default btn-small dropdown-toggle" data-toggle="dropdown" href="#"> Attach File <span class="caret"></span></button>
+        <ul class="dropdown-menu">
+          <li>
+            <%= link_to "Attach Vector", main_app.new_hyrax_file_set_path(@presenter, type: 'vector-data') %>
+          </li>
+          <li>
+            <%= link_to "Attach Metadata", main_app.new_hyrax_file_set_path(@presenter, type: 'metadata') %>
+          </li>
+        </ul>
+      </div>
+    <% end %>
+      <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
+  </div>
+<% end %>

--- a/app/views/hyrax/vector_works/show.html.erb
+++ b/app/views/hyrax/vector_works/show.html.erb
@@ -1,0 +1,23 @@
+<% provide :page_title, @presenter.page_title %>
+<% provide :page_header do %>
+  <%= render "hyrax/base/title_header" %>
+  <% if @parent_presenter %>
+    <ul class="breadcrumb">
+      <li><%= link_to @parent_presenter, polymorphic_path([main_app, @parent_presenter]) %></li>
+      <li class="active"><%= @presenter.human_readable_type %></li>
+    </ul>
+  <% else %>
+    <span class="human_readable_type">(<%= @presenter.human_readable_type %>)</span>
+  <% end %>
+<% end %>
+
+<% collector = can?(:collect, @presenter.id) %>
+<% editor    = can?(:edit,    @presenter.id) %>
+
+<%= render 'geo_works/representative_media', presenter: @presenter %>
+<%= render 'geo_works/metadata', presenter: @presenter %>
+<%= render 'geo_works/relationships', presenter: @presenter %>
+<%= render 'geo_works/related/geo_files', presenter: @presenter %>
+<%= render 'geo_works/related/external_metadata_files', presenter: @presenter %>
+<%= render 'workflow_actions', presenter: @presenter if @presenter.workflow.actions.present? %>
+<%= render "show_actions", collector: collector, editor: editor %>

--- a/spec/factories/raster_works.rb
+++ b/spec/factories/raster_works.rb
@@ -1,0 +1,39 @@
+FactoryGirl.define do
+  factory :raster_work do
+    title ["Test title"]
+    rights_statement ["http://rightsstatements.org/vocab/NKC/1.0/"]
+    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    state Vocab::FedoraResourceStatus.active
+
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    end
+
+    factory :complete_raster_work do
+      after(:create) do |work, evaluator|
+        FactoryGirl.create(:complete_sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+        work.save
+      end
+    end
+
+    factory :pending_raster_work do
+      after(:create) do |work, evaluator|
+        FactoryGirl.create(:pending_sipity_entity, proxy_for_global_id: work.to_global_id.to_s)
+        work.save
+      end
+    end
+
+    factory :raster_work_with_metadata_file do
+      after(:create) do |raster_work, evaluator|
+        file = FactoryGirl.create(:file_set, user: evaluator.user, geo_mime_type: 'application/xml; schema=fgdc')
+        raster_work.ordered_members << file
+        raster_work.save
+        file.update_index
+      end
+    end
+  end
+end

--- a/spec/views/hyrax/raster_works/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/raster_works/_show_actions.html.erb_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe "hyrax/raster_works/_show_actions.html.erb" do
+  let(:resource) do
+    r = FactoryGirl.build(:raster_work)
+    allow(r).to receive(:id).and_return("test")
+    r
+  end
+  let(:solr_document) { SolrDocument.new(resource.to_solr) }
+  let(:presenter) { RasterWorkShowPresenter.new(solr_document, nil) }
+  let(:editor) { true }
+  let(:collector) { true }
+  let(:parent_presenter) {}
+  before do
+    assign(:presenter, presenter)
+    assign(:parent_presenter, parent_presenter)
+    render partial: "hyrax/raster_works/show_actions", locals: { collector: collector, editor: editor }
+  end
+  it "renders an Attach Raster link" do
+    expect(rendered).to have_link 'Attach Raster', href: main_app.new_hyrax_file_set_path(presenter, type: 'raster-data')
+  end
+end

--- a/spec/views/hyrax/raster_works/show.html.erb_spec.rb
+++ b/spec/views/hyrax/raster_works/show.html.erb_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe "hyrax/raster_works/show.html.erb" do
+  let(:resource) do
+    FactoryGirl.build(:raster_work, id: 'test',
+                                    title: ['a raster work'],
+                                    creator: ['Gerardus'],
+                                    date_created: ['1595-01-02'],
+                                    rights: ['No Warping'])
+  end
+  let(:solr_document) { SolrDocument.new(resource.to_solr) }
+  let(:ability) do
+    a = double("ability")
+    allow(a).to receive(:can?).and_return(true)
+    a
+  end
+  let(:presenter) { RasterWorkShowPresenter.new(solr_document, ability) }
+  let(:blacklight_config) { CatalogController.new.blacklight_config }
+  let(:editor) { true }
+  let(:collector) { true }
+  before do
+    stub_blacklight_views
+    assign(:presenter, presenter)
+    allow(view).to receive(:provide).with(:page_title, 'a raster work')
+    allow(view).to receive(:provide).with(:page_header).and_yield
+    render template: "hyrax/raster_works/show", locals: { collector: collector, editor: editor }
+  end
+  it "renders the human readable Work type as Vector Work" do
+    expect(rendered).to have_selector 'span.human_readable_type', text: '(Raster Work)'
+  end
+end

--- a/spec/views/hyrax/vector_works/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/vector_works/_show_actions.html.erb_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe "hyrax/vector_works/_show_actions.html.erb" do
+  let(:resource) do
+    r = FactoryGirl.build(:vector_work)
+    allow(r).to receive(:id).and_return("test")
+    r
+  end
+  let(:solr_document) { SolrDocument.new(resource.to_solr) }
+  let(:presenter) { VectorWorkShowPresenter.new(solr_document, nil) }
+  let(:editor) { true }
+  let(:collector) { true }
+  let(:parent_presenter) {}
+  before do
+    assign(:presenter, presenter)
+    assign(:parent_presenter, parent_presenter)
+    render partial: "hyrax/vector_works/show_actions", locals: { collector: collector, editor: editor }
+  end
+  it "renders an Attach Vector link" do
+    expect(rendered).to have_link 'Attach Vector', href: main_app.new_hyrax_file_set_path(presenter, type: 'vector-data')
+  end
+end

--- a/spec/views/hyrax/vector_works/show.html.erb_spec.rb
+++ b/spec/views/hyrax/vector_works/show.html.erb_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe "hyrax/vector_works/show.html.erb" do
+  let(:resource) do
+    FactoryGirl.build(:vector_work, id: 'test',
+                                    title: ['a vector work'],
+                                    creator: ['Dangermond'],
+                                    date_created: ['1969-12-31'],
+                                    rights: ['In Copyright'])
+  end
+  let(:solr_document) { SolrDocument.new(resource.to_solr) }
+  let(:ability) do
+    a = double("ability")
+    allow(a).to receive(:can?).and_return(true)
+    a
+  end
+  let(:presenter) { VectorWorkShowPresenter.new(solr_document, ability) }
+  let(:blacklight_config) { CatalogController.new.blacklight_config }
+  let(:editor) { true }
+  let(:collector) { true }
+  before do
+    stub_blacklight_views
+    assign(:presenter, presenter)
+    allow(view).to receive(:provide).with(:page_title, 'a vector work')
+    allow(view).to receive(:provide).with(:page_header).and_yield
+    render template: "hyrax/vector_works/show", locals: { collector: collector, editor: editor }
+  end
+  it "renders the human readable Work type as Vector Work" do
+    expect(rendered).to have_selector 'span.human_readable_type', text: '(Vector Work)'
+  end
+end


### PR DESCRIPTION
Resolves #1336 by:
- Overriding the "show" templates and "show_actions" Partials for RasterWorks and VectorWorks (ensuring that there is a common structure between these and ImageWorks)
- Implementing a Factory for RasterWorks in order to support the RSpec suites