### PR TITLE
Collapses the tabs on the FileSet edit View

### DIFF
--- a/app/views/hyrax/file_sets/_form.html.erb
+++ b/app/views/hyrax/file_sets/_form.html.erb
@@ -1,0 +1,23 @@
+<%= simple_form_for [main_app, file_set],
+                    html: { multipart: true, data: { param_key: file_set.model_name.param_key } } do |f| %>
+  <fieldset class="required">
+    <span class="control-label">
+      <%= label_tag 'file_set[title][]', 'Title',  class: "string optional" %>
+    </span>
+    <%= text_field_tag 'file_set[title][]', file_set.title.first, class: 'form-control', required: true %>
+  </fieldset>
+
+  <fieldset class="required">
+    <%= render "permission_form", f: f %>
+  </fieldset>
+
+  <div class="row">
+    <div class="col-md-12 form-actions">
+      <%= f.submit(
+        (file_set.persisted? ? "Update Attached File" : %(Attach to #{file_set.parent.human_readable_type})),
+        class: 'btn btn-primary'
+      ) %>
+      <%= link_to 'Cancel', parent_path(file_set.parent), class: 'btn btn-link' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/hyrax/file_sets/edit.html.erb
+++ b/app/views/hyrax/file_sets/edit.html.erb
@@ -8,20 +8,11 @@
     <%= media_display curation_concern.to_presenter %>
   </div>
   <div class="col-xs-12 col-sm-8">
-    <ul class="nav nav-tabs" role="tablist">
-      <li id="edit_descriptions_link" class="active">
-        <a href="#descriptions_display" data-toggle="tab"><i class="fa fa-tags"></i> Descriptions</a>
-      </li>
-      <li id="edit_permissions_link">
-        <a href="#permissions_display" data-toggle="tab"><i class="fa fa-key"></i> Permissions</a>
-      </li>
-    </ul>
-    <div class="tab-content">
-      <div id="descriptions_display" class="tab-pane active">
+    <div>
+      <div id="descriptions_display">
         <h2>Descriptions </h2>
-        <%= render "form" %>
+        <%= render "form", file_set: curation_concern %>
       </div>
-      <%= render "permission", file_set: curation_concern %>
     </div>
   </div><!-- /.col-sm-8 -->
 </div><!-- /.row -->

--- a/spec/features/edit_file_set_spec.rb
+++ b/spec/features/edit_file_set_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.feature 'Editing a FileSet', type: :feature do
+  let(:user) { FactoryGirl.create(:image_editor) }
+  let(:image_resource) do
+    FactoryGirl.build(:image_work,
+                      id: 'test',
+                      user: user)
+  end
+  let(:parent_presenter) do
+    ImageWorkShowPresenter.new(
+      SolrDocument.new(
+        image_resource.to_solr
+      ), nil
+    )
+  end
+  let(:file_title) { 'Some kind of title' }
+  let(:file_set) { FactoryGirl.create(:file_set, user: user, title: [file_title], visibility: 'open') }
+  let(:file) { File.open(File.join(fixture_path, '/files/image.png')) }
+
+  before do
+    sign_in user
+    Hydra::Works::AddFileToFileSet.call(file_set, file, :original_file)
+    image_resource.ordered_members << file_set
+    image_resource.save!
+  end
+
+  context 'when the user sets an attached file to be privately accessible' do
+    it 'updates the visibility of the file' do
+      visit polymorphic_path [:edit, parent_presenter.member_presenters.first]
+      expect(page).to have_content "Edit #{file_title}"
+      choose('Private')
+      click_button 'Update Attached File'
+      visit polymorphic_path [:edit, parent_presenter.member_presenters.first]
+      expect(find("#file_set_visibility_restricted")).to be_checked
+    end
+  end
+end

--- a/spec/views/hyrax/file_sets/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_form.html.erb_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe 'hyrax/file_sets/_form.html.erb', type: :view do
+  let(:user) { instance_double(User, user_key: 'sarah') }
+  let(:curation_concern) do
+    FactoryGirl.build(:image_work,
+                      id: 'test',
+                      title: ['an image work'],
+                      creator: ['John Smith'],
+                      date_created: ['1595-01-02'],
+                      rights: ['Public Domain'])
+  end
+  let(:file_set) do
+    file_set = FactoryGirl.build(:file_set, id: '123', title: ['an image file'], depositor: user.user_key, user: user, visibility: 'open')
+    curation_concern.ordered_members << file_set
+    curation_concern.save
+    file_set
+  end
+
+  before do
+    render partial: 'hyrax/file_sets/form', locals: { file_set: file_set }
+  end
+
+  it "draws the permissions form without error" do
+    expect(rendered).to have_css('#permissions_display')
+    expect(rendered).to have_css('.set-access-controls')
+  end
+end

--- a/spec/views/hyrax/file_sets/_permission_form.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_permission_form.html.erb_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe 'hyrax/file_sets/_permission_form.html.erb', type: :view do
+  let(:user) { instance_double(User, user_key: 'sarah') }
+  let(:curation_concern) do
+    FactoryGirl.build(:image_work,
+                      id: 'test',
+                      title: ['an image work'],
+                      creator: ['John Smith'],
+                      date_created: ['1595-01-02'],
+                      rights: ['Public Domain'])
+  end
+  let(:file_set) do
+    file_set = FactoryGirl.build(:file_set, id: '123', title: ['an image file'], depositor: user.user_key, user: user, visibility: 'open')
+    curation_concern.ordered_members << file_set
+    curation_concern.save
+    file_set
+  end
+
+  let(:form) do
+    view.simple_form_for(file_set, url: '/update') do |fs_form|
+      return fs_form
+    end
+  end
+
+  before do
+    allow(view).to receive(:f).and_return(form)
+    render partial: 'hyrax/file_sets/permission_form', locals: { file_set: file_set }
+  end
+
+  it "draws the permissions form without error" do
+    expect(rendered).to have_css('#permissions_display')
+    expect(rendered).to have_css('.set-access-controls')
+  end
+end

--- a/spec/views/hyrax/file_sets/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/edit.html.erb_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe 'hyrax/file_sets/edit.html.erb', type: :view do
+  let(:user) { instance_double(User, user_key: 'sarah') }
+  let(:curation_concern) do
+    FactoryGirl.build(:image_work,
+                      id: 'test',
+                      title: ['an image work'],
+                      creator: ['John Smith'],
+                      date_created: ['1595-01-02'],
+                      rights: ['Public Domain'])
+  end
+  let(:file_set) do
+    file_set = FactoryGirl.build(:file_set, id: '123', title: ['an image file'], depositor: user.user_key, user: user, visibility: 'open')
+    curation_concern.ordered_members << file_set
+    curation_concern.save
+    file_set
+  end
+  let(:solr_document) { SolrDocument.new(file_set.to_solr) }
+
+  before do
+    allow(file_set).to receive(:to_presenter).and_return(solr_document)
+    allow(view).to receive(:provide).with(:page_title, 'an image file // File [123] // Digital PUL')
+    allow(view).to receive(:provide).with(:page_header).and_yield
+    render template: 'hyrax/file_sets/edit', locals: { curation_concern: file_set }
+  end
+
+  it "draws the permissions form without error" do
+    expect(rendered).to have_css('#permissions_display')
+    expect(rendered).to have_css('.set-access-controls')
+  end
+end


### PR DESCRIPTION
Resolves #1174:
- Collapses the tabs on the FileSet edit View
- Uses a single button for saving/updating the FileSet
