### PR TITLE
Fix Ephemera Folder Manifests

### DIFF
--- a/app/actors/hyrax/actors/ephemera_folder_actor.rb
+++ b/app/actors/hyrax/actors/ephemera_folder_actor.rb
@@ -2,7 +2,7 @@
 #  `rails generate hyrax:work EphemeraFolder`
 module Hyrax
   module Actors
-    class EphemeraFolderActor < Hyrax::Actors::BaseActor
+    class EphemeraFolderActor < PlumActor
       def create(attributes)
         box_id = attributes.delete(:box_id)
         assign_box(box_id) && super

--- a/app/controllers/concerns/hyrax/manifest.rb
+++ b/app/controllers/concerns/hyrax/manifest.rb
@@ -3,6 +3,7 @@ module Hyrax::Manifest
 
   included do
     def manifest
+      authorize! :manifest, presenter
       respond_to do |f|
         f.json do
           render json: manifest_builder

--- a/app/services/workflow/updated_event.rb
+++ b/app/services/workflow/updated_event.rb
@@ -1,7 +1,7 @@
 module Workflow
   class UpdatedEvent
     def self.call(target:, **)
-      return unless target.is_a?(ScannedResource) || target.is_a?(MultiVolumeWork)
+      return unless target.is_a?(ScannedResource) || target.is_a?(MultiVolumeWork) || target.is_a?(EphemeraFolder)
       target.save
       messenger.record_updated(target)
       true

--- a/config/workflows/folder_workflow.json
+++ b/config/workflows/folder_workflow.json
@@ -25,6 +25,7 @@
             }
           ],
           "methods": [
+            "Workflow::UpdatedEvent"
           ],
           "transition_to": "needs_qa"
         },
@@ -40,7 +41,8 @@
             }
           ],
           "methods": [
-            "Workflow::CompleteRecord"
+            "Workflow::CompleteRecord",
+            "Workflow::UpdatedEvent"
           ],
           "transition_to": "complete"
         }


### PR DESCRIPTION
This stops manifests from rendering if you don't have permission, and
makes it so that Ephemera Folders fire a RabbitMQ event on workflow
movements.