### PR TITLE
Allow ingesting volumes first, then adding to MVW

### DIFF
--- a/app/jobs/ingest_service_job.rb
+++ b/app/jobs/ingest_service_job.rb
@@ -1,8 +1,7 @@
 class IngestServiceJob < ApplicationJob
   queue_as :ingest
 
-  def perform(dir, bib, user, coll_id, local_id)
-    coll = ActiveFedora::Base.find(coll_id)
-    IngestService.new(@logger).ingest_dir dir, bib, user, coll, local_id
+  def perform(dir, bib, user, params)
+    IngestService.new(@logger).ingest_dir dir, bib, user, params
   end
 end

--- a/spec/jobs/ingest_mets_job_spec.rb
+++ b/spec/jobs/ingest_mets_job_spec.rb
@@ -120,6 +120,17 @@ RSpec.describe IngestMETSJob, :admin_set do
       expect(work.ordered_member_ids).to eq(['resource1', 'resource2'])
     end
 
+    context "when the volumes have already been ingested" do
+      let(:resource1) { FactoryGirl.create(:scanned_resource_with_file, replaces: ['pudl0001/4609321/s42/phys1']) }
+      let(:resource2) { FactoryGirl.create(:scanned_resource_with_file, replaces: ['pudl0001/4609321/s42/phys2']) }
+      it "ingests a multi-volume mets file", vcr: { cassette_name: 'bibdata-4609321' } do
+        allow(actor1).to receive(:attach_related_object)
+        allow(actor1).to receive(:attach_content)
+        described_class.perform_now(mets_file_multi, user)
+        expect(work.ordered_member_ids).to eq([resource1.id, resource2.id])
+      end
+    end
+
     context "when given a pudl0003 MVW with no structmap", vcr: { cassette_name: 'bibdata-4612596' } do
       let(:mets_file) { Rails.root.join("spec", "fixtures", "pudl0003-tc85_2621.mets") }
       it "hacks together a MVW from the path" do

--- a/spec/services/ingest_service_spec.rb
+++ b/spec/services/ingest_service_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe IngestService, :admin_set do
   let(:user) { FactoryGirl.create(:admin) }
   let(:bib) { '4609321' }
   let(:local_id) { 'cico:xyz' }
+  let(:replaces) { 'pudl0001/4609321/331' }
   let(:resource1) { ScannedResource.new }
   let(:resource2) { ScannedResource.new }
   let(:multivol) { MultiVolumeWork.new }
@@ -20,11 +21,12 @@ RSpec.describe IngestService, :admin_set do
         allow(ScannedResource).to receive(:new).and_return(resource1)
       end
       it 'ingests them as a ScannedResource' do
-        subject.ingest_dir single_dir, bib, user, coll, local_id
+        subject.ingest_dir single_dir, bib, user, collection: coll, local_id: local_id, replaces: replaces
         expect(resource1.file_sets.length).to eq 2
         expect(resource1.ordered_members.to_a.map(&:label)).to eq ['color.tif', 'gray.tif']
         expect(resource1.member_of_collection_ids).to eq [coll.id]
         expect(resource1.local_identifier).to eq [local_id]
+        expect(resource1.replaces).to eq [replaces]
       end
     end
 
@@ -34,7 +36,7 @@ RSpec.describe IngestService, :admin_set do
         allow(ScannedResource).to receive(:new).and_return(resource1, resource2)
       end
       it 'ingests them as a MultiVolumeWork' do
-        subject.ingest_dir multi_dir, bib, user
+        subject.ingest_dir multi_dir, bib, user, {}
         expect(multivol.ordered_members.to_a.length).to eq 2
         expect(multivol.ordered_members).to eq [resource1, resource2]
       end


### PR DESCRIPTION
Allows ingesting each volume of a multi-volume work separately:

```
bundle exec rake bulk:ingest DIR=/path/to/vol1 REPLACES=pudl0001/3499396/vol1
```

and then creating a MVW that bundles them together:

```
bundle exec rake mets:ingest /path/to/mets/files/
```

Fixes #1449 