### PR TITLE
Ensures that anonymous users can download PDF's

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,8 +10,8 @@ class Ability
 
   # Define any customized permissions here.
   def custom_permissions
-    alias_action :show, :manifest, to: :read
-    alias_action :color_pdf, :pdf, :edit, :browse_everything_files, to: :modify
+    alias_action :show, :manifest, :color_pdf, :pdf, to: :read
+    alias_action :edit, :browse_everything_files, to: :modify
     roles.each do |role|
       send "#{role}_permissions" if current_user.send "#{role}?"
     end
@@ -175,8 +175,14 @@ class Ability
     cannot [:manifest], EphemeraFolderPresenter do |folder|
       folder.workflow_state == "needs_qa"
     end
+    can :pdf, FileSet do |file_set|
+      file_set.in_works.map { |curation_concern| ["color", "gray"].include?(Array(curation_concern.pdf_type).first) }.reduce(:|)
+    end
     can :pdf, (curation_concerns + [ScannedResourceShowPresenter]) do |curation_concern|
       ["color", "gray"].include?(Array(curation_concern.pdf_type).first)
+    end
+    can :color_pdf, FileSet do |file_set|
+      file_set.in_works.map { |curation_concern| curation_concern.pdf_type == ["color"] }.reduce(:|)
     end
     can :color_pdf, (curation_concerns + [ScannedResourceShowPresenter]) do |curation_concern|
       curation_concern.pdf_type == ["color"]

--- a/spec/ability/roles_spec.rb
+++ b/spec/ability/roles_spec.rb
@@ -148,8 +148,8 @@ describe Ability do
     it {
       should be_able_to(:read, open_scanned_resource)
       should be_able_to(:manifest, open_scanned_resource)
-      should be_able_to(:pdf, open_scanned_resource)
-      should_not be_able_to(:color_pdf, open_scanned_resource)
+      should be_able_to(:pdf, presenter(open_scanned_resource))
+      should_not be_able_to(:color_pdf, presenter(open_scanned_resource))
       should be_able_to(:read, campus_only_scanned_resource)
       should_not be_able_to(:read, private_scanned_resource)
       should_not be_able_to(:read, pending_scanned_resource)
@@ -462,7 +462,7 @@ describe Ability do
       should be_able_to(:color_pdf, color_enabled_resource)
       should be_able_to(:download, external_metadata_file)
 
-      should_not be_able_to(:pdf, no_pdf_scanned_resource)
+      should_not be_able_to(:pdf, presenter(no_pdf_scanned_resource))
       should_not be_able_to(:flag, open_scanned_resource)
       should_not be_able_to(:read, campus_only_scanned_resource)
       should_not be_able_to(:read, private_scanned_resource)

--- a/spec/controllers/hyrax/downloads_controller_spec.rb
+++ b/spec/controllers/hyrax/downloads_controller_spec.rb
@@ -15,20 +15,44 @@ RSpec.describe Hyrax::DownloadsController do
   end
 
   describe 'grayscale pdf download' do
-    before { sign_in user }
+    context 'as an authenticated user' do
+      before { sign_in user }
 
-    it 'sends the file' do
-      get :show, params: { id: file_set.to_param, file: 'gray-pdf' }
-      expect(response.headers['Content-Length']).to eq file.size.to_s
+      it 'sends the file' do
+        get :show, params: { id: file_set.to_param, file: 'gray-pdf' }
+        expect(response.headers['Content-Length']).to eq file.size.to_s
+      end
+    end
+
+    context 'as an anonymous user' do
+      let(:scanned_resource) { FactoryGirl.create(:scanned_resource_with_file) }
+      let(:file_set) { scanned_resource.file_sets.first }
+
+      it 'sends the file' do
+        get :show, params: { id: file_set.to_param, file: 'gray-pdf' }
+        expect(response.headers['Content-Length']).to eq file.size.to_s
+      end
     end
   end
 
   describe 'color pdf download' do
-    before { sign_in user }
+    context 'as an authenticated user' do
+      before { sign_in user }
 
-    it 'sends the file' do
-      get :show, params: { id: file_set.to_param, file: 'color-pdf' }
-      expect(response.headers['Content-Length']).to eq file.size.to_s
+      it 'sends the file' do
+        get :show, params: { id: file_set.to_param, file: 'color-pdf' }
+        expect(response.headers['Content-Length']).to eq file.size.to_s
+      end
+    end
+
+    context 'as an anonymous user' do
+      let(:scanned_resource) { FactoryGirl.create(:scanned_resource_with_file, pdf_type: ["color"]) }
+      let(:file_set) { scanned_resource.file_sets.first }
+
+      it 'sends the file' do
+        get :show, params: { id: file_set.to_param, file: 'color-pdf' }
+        expect(response.headers['Content-Length']).to eq file.size.to_s
+      end
     end
   end
 


### PR DESCRIPTION
Resolves #1446 by restructuring:
- the CanCanCan Abilities for accessing PDF's for FileSets and CurationConcerns as an anonymous user