### PR TITLE
Ensures that the Universal Viewer is not rendered for invalid IIIF resources

### DIFF
--- a/app/controllers/concerns/hyrax/collection_manifest.rb
+++ b/app/controllers/concerns/hyrax/collection_manifest.rb
@@ -1,11 +1,11 @@
-module Hyrax::Manifest
+module Hyrax::CollectionManifest
   extend ActiveSupport::Concern
 
   included do
-    def manifest
+    def index_manifest
       respond_to do |f|
         f.json do
-          render json: manifest_builder
+          render json: all_manifests_builder
         end
       end
     rescue CanCan::AccessDenied => access_err
@@ -43,10 +43,8 @@ module Hyrax::Manifest
     ##
     # Retrieve the IIIF Manifest for a given Work
     # @return IIIF::Presentation::Manifest
-    def manifest_builder
-      Rails.cache.fetch("manifest/#{presenter.id}/#{ResourceIdentifier.new(presenter.id)}") do
-        PolymorphicManifestBuilder.new(presenter, ssl: request.ssl?).to_json
-      end
+    def all_manifests_builder
+      AllCollectionsManifestBuilder.new(nil, ability: current_ability, ssl: request.ssl?).to_json
     end
 
     def login_url

--- a/app/controllers/hyrax/collections_controller.rb
+++ b/app/controllers/hyrax/collections_controller.rb
@@ -1,37 +1,13 @@
 class Hyrax::CollectionsController < ApplicationController
+  include Hyrax::Manifest
+  include Hyrax::CollectionManifest
   include Hyrax::CollectionsControllerBehavior
   skip_load_and_authorize_resource only: :index_manifest
   skip_before_action :authenticate_user!, only: [:index_manifest, :manifest]
   self.presenter_class = CollectionShowPresenter
   self.form_class = CollectionEditForm
 
-  def manifest
-    respond_to do |f|
-      f.json do
-        render json: manifest_builder
-      end
-    end
-  end
-
-  def index_manifest
-    respond_to do |f|
-      f.json do
-        render json: all_manifests_builder
-      end
-    end
-  end
-
   def current_ability
     ::Ability.new(current_user, auth_token: params[:auth_token])
   end
-
-  private
-
-    def manifest_builder
-      @manifest_builder ||= SparseMemberCollectionManifest.new(presenter, ssl: request.ssl?)
-    end
-
-    def all_manifests_builder
-      @all_manifests_builder ||= AllCollectionsManifestBuilder.new(nil, ability: current_ability, ssl: request.ssl?)
-    end
 end

--- a/app/controllers/hyrax/hyrax_controller.rb
+++ b/app/controllers/hyrax/hyrax_controller.rb
@@ -11,6 +11,18 @@ class Hyrax::HyraxController < ApplicationController
     super
   end
 
+  ##
+  # Override the "show" action
+  # Ensures that the URI for the IIIF Manifest and the Manifest itself are passed to the view
+  def show
+    @manifest_uri = polymorphic_path([main_app, :manifest, presenter])
+    @manifest = manifest_builder
+  rescue
+    Rails.logger.warn I18n.t('works.show.no_image')
+  ensure
+    super
+  end
+
   def file_manager
     parent_presenter
     @form = ::FileManagerForm.new(curation_concern, current_ability)

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -2,6 +2,8 @@ class ManifestBuilder
   attr_reader :record, :services
   delegate :to_json, to: :manifest
 
+  class ManifestBuildError < EncodingError; end
+
   def initialize(record, ssl: false, services: nil)
     @record = record
     @ssl = ssl

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -3,6 +3,7 @@ class ManifestBuilder
   delegate :to_json, to: :manifest
 
   class ManifestBuildError < EncodingError; end
+  class ManifestEmptyError < StandardError; end
 
   def initialize(record, ssl: false, services: nil)
     @record = record

--- a/app/services/polymorphic_manifest_builder.rb
+++ b/app/services/polymorphic_manifest_builder.rb
@@ -5,14 +5,23 @@ class PolymorphicManifestBuilder
     # @param [SolrDocument] solr_document the Document for the Work
     # @param args additional arguments passed to the manifest builder
     def new(solr_document, *args)
-      manifest = if solr_document.member_presenters.map(&:class).uniq.length > 1
-                   sammelband_manifest_builder.new(solr_document, *args)
-                 elsif solr_document.is_a? MapSetShowPresenter
-                   sammelband_manifest_builder.new(solr_document, *args)
-                 else
-                   manifest_builder.new(solr_document, *args)
-                 end
-      raise ManifestBuilder::ManifestBuildError, I18n.t('works.show.no_image') if JSON.parse(manifest.to_json).blank?
+      begin
+        manifest = if solr_document.member_presenters.map(&:class).uniq.length > 1
+                     sammelband_manifest_builder.new(solr_document, *args)
+                   elsif solr_document.is_a? CollectionShowPresenter
+                     collection_manifest_builder.new(solr_document, *args)
+                   elsif solr_document.is_a? MapSetShowPresenter
+                     sammelband_manifest_builder.new(solr_document, *args)
+                   else
+                     manifest_builder.new(solr_document, *args)
+                   end
+      rescue
+        raise ManifestBuilder::ManifestBuildError, I18n.t('works.show.no_image')
+      end
+
+      if JSON.parse(manifest.to_json).blank?
+        raise ManifestBuilder::ManifestEmptyError, I18n.t('works.show.no_image')
+      end
       manifest
     end
 
@@ -24,6 +33,10 @@ class PolymorphicManifestBuilder
 
       def sammelband_manifest_builder
         SammelbandManifestBuilder
+      end
+
+      def collection_manifest_builder
+        SparseMemberCollectionManifest
       end
   end
 end

--- a/app/services/polymorphic_manifest_builder.rb
+++ b/app/services/polymorphic_manifest_builder.rb
@@ -1,13 +1,19 @@
 class PolymorphicManifestBuilder
   class << self
+    ##
+    # Constructor for ManifestBuilders of all Works
+    # @param [SolrDocument] solr_document the Document for the Work
+    # @param args additional arguments passed to the manifest builder
     def new(solr_document, *args)
-      if solr_document.member_presenters.map(&:class).uniq.length > 1
-        sammelband_manifest_builder.new(solr_document, *args)
-      elsif solr_document.is_a? MapSetShowPresenter
-        sammelband_manifest_builder.new(solr_document, *args)
-      else
-        manifest_builder.new(solr_document, *args)
-      end
+      manifest = if solr_document.member_presenters.map(&:class).uniq.length > 1
+                   sammelband_manifest_builder.new(solr_document, *args)
+                 elsif solr_document.is_a? MapSetShowPresenter
+                   sammelband_manifest_builder.new(solr_document, *args)
+                 else
+                   manifest_builder.new(solr_document, *args)
+                 end
+      raise ManifestBuilder::ManifestBuildError, I18n.t('works.show.no_image') if JSON.parse(manifest.to_json).blank?
+      manifest
     end
 
     private

--- a/app/views/hyrax/base/_file_manager_attributes.html.erb
+++ b/app/views/hyrax/base/_file_manager_attributes.html.erb
@@ -1,3 +1,5 @@
 <% if node.model_name.singular == "file_set" %>
-  <%= f.input :viewing_hint, collection: [:"", :"non-paged", :"facing-pages"], as: :radio_buttons, label: false, defaults: { input_html: { class: '' }}%>
+  <% if node.respond_to? :viewing_hint %>
+    <%= f.input :viewing_hint, collection: [:"", :"non-paged", :"facing-pages"], as: :radio_buttons, label: false, defaults: { input_html: { class: '' }}%>
+  <% end %>
 <% end %>

--- a/app/views/hyrax/base/_file_manager_thumbnail.html.erb
+++ b/app/views/hyrax/base/_file_manager_thumbnail.html.erb
@@ -1,3 +1,5 @@
-<%= osd_modal_for(node.thumbnail_id) do %>
-  <%= render_thumbnail_tag node, { class: 'thumbnail-inner', onerror: default_icon_fallback } %>
+<% if node.respond_to? :thumbnail_id %>
+  <%= osd_modal_for(node.thumbnail_id) do %>
+    <%= render_thumbnail_tag node, { class: 'thumbnail-inner', onerror: default_icon_fallback } %>
+  <% end %>
 <% end %>

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -1,5 +1,5 @@
-<% if can?(:manifest, presenter) && presenter.respond_to?(:member_presenters) && presenter.member_presenters.present? %>
-  <div class="uv viewer" data-config="/uv_config.json" data-uri="<%= main_app.polymorphic_path([main_app,:manifest,presenter]) %>" ></div>
+<% if can?(:manifest, presenter) && presenter.respond_to?(:member_presenters) && presenter.member_presenters.present? && @manifest.present? %>
+  <div class="uv viewer" data-config="/uv_config.json" data-uri="<%= @manifest_uri %>" ></div>
   <%= PulUvRails::UniversalViewer.script_tag %>
 <% else %>
   <%= image_tag 'nope.png', class: "canonical-image" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,3 +78,6 @@ en:
     all_in_production:
       label: 'All in Production'
       desc: 'Mark all contained folders as having received QA, and put them into the public display.'
+  works:
+    show:
+      no_image: "Image cannot be viewed at this time."

--- a/spec/controllers/hyrax/collection_manifest_spec.rb
+++ b/spec/controllers/hyrax/collection_manifest_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::CollectionManifest do
+  let(:user) { FactoryGirl.create(:admin) }
+  let(:collection) do
+    collection = MyCollection.new(id: '123', title: ['test title'])
+    collection.save
+    collection
+  end
+  let(:manifest_helper_class) { class_double(ManifestBuilder::ManifestHelper).as_stubbed_const(transfer_nested_constants: true) }
+  let(:manifest_helper) { double }
+
+  before do
+    class MyCollection < ActiveFedora::Base
+      include ::Hyrax::CollectionBehavior
+      include Hyrax::BasicMetadata
+    end
+
+    class MyCollectionController < Hyrax::HyraxController
+      include Hyrax::Manifest
+      include Hyrax::CollectionManifest
+      include Hyrax::CollectionsControllerBehavior
+
+      self.curation_concern_type = MyCollection
+    end
+
+    routes.draw { get 'my_collection/index_manifest' => "my_collection#index_manifest" }
+    @controller = MyCollectionController.new
+    allow(@controller).to receive(:search_results).and_return([nil, [collection.to_solr]])
+
+    allow(manifest_helper_class).to receive(:new).and_return(manifest_helper)
+    allow(manifest_helper).to receive(:root_url).and_return("http://localhost")
+  end
+
+  after do
+    Rails.application.reload_routes!
+    Object.send(:remove_const, :MyCollection)
+    Object.send(:remove_const, :MyCollectionController)
+  end
+
+  describe '#index_manifest' do
+    context 'as an authenticated user' do
+      before { sign_in user }
+
+      it 'returns a valid manifest for a collection', manifest: true do
+        get :index_manifest, params: { id: collection.id, format: :json }
+        expect(response.status).to eq 200
+        response_json = JSON.parse(response.body)
+        expect(response_json).not_to be_empty
+      end
+    end
+
+    context 'as an unauthenticated user' do
+      let(:user) {}
+      it 'returns a 401 status' do
+        get :index_manifest, params: { id: collection.id, format: :json }
+        expect(response.status).to eq 401
+      end
+    end
+
+    context 'with an invalid manifest' do
+      before do
+        sign_in user
+        allow(@controller).to receive(:all_manifests_builder).and_raise(ManifestBuilder::ManifestBuildError, 'Test error message')
+      end
+
+      it 'provides a 500 status code and serves an error message' do
+        get :index_manifest, params: { id: collection.id, format: :json }
+        expect(response.status).to eq 500
+        response_json = JSON.parse(response.body)
+        expect(response_json).to include 'message' => 'Test error message'
+      end
+    end
+
+    context 'with an empty manifests' do
+      let(:manifest) { instance_double(IIIF::Presentation::Manifest) }
+
+      before do
+        sign_in user
+        allow(manifest).to receive(:to_json).and_return("{}")
+        allow(@controller).to receive(:all_manifests_builder).and_raise(ManifestBuilder::ManifestEmptyError)
+      end
+
+      it 'provides a 404 status code and serves an empty JSON response' do
+        get :index_manifest, params: { id: collection.id, format: :json }
+        expect(response.status).to eq 404
+        response_json = JSON.parse(response.body)
+        expect(response_json).to be_empty
+      end
+    end
+  end
+
+  describe '#deny_access' do
+    context 'as an unauthenticated user' do
+      let(:user) {}
+      it 'returns a 401 status' do
+        get :index_manifest, params: { id: collection.id, format: :json }
+        expect(response.status).to eq 401
+      end
+    end
+  end
+end

--- a/spec/controllers/hyrax/manifest_spec.rb
+++ b/spec/controllers/hyrax/manifest_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::Manifest do
+  let(:user) { FactoryGirl.create(:admin) }
+  let(:work) do
+    work = MyWork.new(id: '123', title: ['test title'])
+    work.save
+    work
+  end
+
+  before do
+    class MyWork < ActiveFedora::Base
+      include Hyrax::WorkBehavior
+      include Hyrax::BasicMetadata
+      self.valid_child_concerns = []
+    end
+
+    class MyWorkController < Hyrax::HyraxController
+      include Hyrax::Manifest
+      self.curation_concern_type = MyWork
+    end
+
+    routes.draw { get 'my_work/manifest' => "my_work#manifest" }
+    @controller = MyWorkController.new
+    allow(@controller).to receive(:search_results).and_return([nil, [work.to_solr]])
+  end
+
+  after do
+    Rails.application.reload_routes!
+    Object.send(:remove_const, :MyWork)
+    Object.send(:remove_const, :MyWorkController)
+  end
+
+  describe '#manifest' do
+    context 'as an authenticated user' do
+      before { sign_in user }
+
+      it 'returns a valid manifest for a work' do
+        get :manifest, params: { id: work.id, format: :json }
+        expect(response).to be_success
+        response_json = JSON.parse(response.body)
+        expect(response_json).to be_empty
+      end
+    end
+
+    context 'as an unauthenticated user' do
+      it 'returns a 401 status and an empty manifest for a work' do
+        get :manifest, params: { id: work.id, format: :json }
+        expect(response).not_to be_success
+        response_json = JSON.parse(response.body)
+        expect(response_json).to be_empty
+      end
+    end
+
+    context 'with an invalid manifest' do
+      before do
+        sign_in user
+        allow(@controller).to receive(:manifest_builder).and_raise(ManifestBuilder::ManifestBuildError, 'Test error message')
+      end
+
+      it 'returns a valid manifest for a work' do
+        get :manifest, params: { id: work.id, format: :json }
+        expect(response).not_to be_success
+        response_json = JSON.parse(response.body)
+        expect(response_json).to include 'message' => 'Test error message'
+      end
+    end
+  end
+
+  describe '#deny_access' do
+    context 'as an unauthenticated user' do
+      it 'returns a 401 status and an empty manifest for a work' do
+        get :manifest, params: { id: work.id, format: :json }
+        expect(response).not_to be_success
+        response_json = JSON.parse(response.body)
+        expect(response_json).to be_empty
+      end
+    end
+  end
+end

--- a/spec/controllers/hyrax/map_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/map_sets_controller_spec.rb
@@ -85,6 +85,20 @@ RSpec.describe Hyrax::MapSetsController, admin_set: true do
           expect(response_json['manifests']).to be_nil
         end
       end
+
+      context 'when the manifest is empty or invalid' do
+        let(:manifest) { instance_double(IIIF::Presentation::Manifest) }
+
+        it 'returns an error message' do
+          allow(manifest).to receive(:to_json).and_return("{}")
+          allow(SammelbandManifestBuilder).to receive(:new).and_return(manifest)
+
+          get :manifest, params: { id: map_set.id, format: :json }
+
+          response_json = JSON.parse(response.body)
+          expect(response_json).to be_empty
+        end
+      end
     end
 
     describe "#geoblacklight" do

--- a/spec/services/polymorphic_manifest_builder_spec.rb
+++ b/spec/services/polymorphic_manifest_builder_spec.rb
@@ -481,13 +481,25 @@ RSpec.describe PolymorphicManifestBuilder, vcr: { cassette_name: "iiif_manifest"
       let(:manifest_builder) { class_double(ManifestBuilder).as_stubbed_const(transfer_nested_constants: true) }
       let(:manifest) { instance_double(IIIF::Presentation::Manifest) }
 
-      before do
-        allow(manifest).to receive(:to_json).and_return("{}")
-        allow(manifest_builder).to receive(:new).and_return(manifest)
+      context 'with an invalid manifest' do
+        before do
+          allow(manifest).to receive(:to_json).and_return("{}")
+          allow(manifest_builder).to receive(:new).and_return(manifest)
+        end
+
+        it 'raises an error if the manifest is blank' do
+          expect { described_class.new(solr_document) }.to raise_error(ManifestBuilder::ManifestEmptyError, I18n.t('works.show.no_image'))
+        end
       end
 
-      it 'raises an error if the manifest is blank' do
-        expect { described_class.new(solr_document) }.to raise_error(ManifestBuilder::ManifestBuildError, I18n.t('works.show.no_image'))
+      context 'with an empty manifest' do
+        before do
+          allow(manifest_builder).to receive(:new).and_raise(StandardError)
+        end
+
+        it 'raises an error if the manifest is invalid' do
+          expect { described_class.new(solr_document) }.to raise_error(ManifestBuilder::ManifestBuildError, I18n.t('works.show.no_image'))
+        end
       end
     end
   end

--- a/spec/services/polymorphic_manifest_builder_spec.rb
+++ b/spec/services/polymorphic_manifest_builder_spec.rb
@@ -475,4 +475,20 @@ RSpec.describe PolymorphicManifestBuilder, vcr: { cassette_name: "iiif_manifest"
       end
     end
   end
+
+  context 'with an invalid IIIF Manifest' do
+    describe '.new' do
+      let(:manifest_builder) { class_double(ManifestBuilder).as_stubbed_const(transfer_nested_constants: true) }
+      let(:manifest) { instance_double(IIIF::Presentation::Manifest) }
+
+      before do
+        allow(manifest).to receive(:to_json).and_return("{}")
+        allow(manifest_builder).to receive(:new).and_return(manifest)
+      end
+
+      it 'raises an error if the manifest is blank' do
+        expect { described_class.new(solr_document) }.to raise_error(ManifestBuilder::ManifestBuildError, I18n.t('works.show.no_image'))
+      end
+    end
+  end
 end

--- a/spec/views/hyrax/base/_representative_media.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_representative_media.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "hyrax/base/_representative_media.html.erb" do
   before do
     allow(presenter).to receive(:to_model).and_return(presenter)
     allow(view).to receive(:can?).with(:manifest, presenter).and_return(can_manifest)
+    assign(:manifest_uri, 'http://localhost')
     render partial: "hyrax/base/representative_media", locals: { presenter: presenter }
   end
   context "when there are no generic files" do
@@ -17,12 +18,25 @@ RSpec.describe "hyrax/base/_representative_media.html.erb" do
   context "when there are generic files" do
     let(:member_presenters) { [1] }
     it "renders the viewer" do
+      assign(:manifest, test: 'test')
+      render partial: "hyrax/base/representative_media", locals: { presenter: presenter }
+
       expect(response).to have_selector ".viewer[data-uri]"
     end
     context "and the user doesn't have permission to manifest" do
       let(:can_manifest) { false }
       it "doesn't render the viewer" do
         expect(response).to have_selector "img[src='/assets/nope.png']"
+      end
+    end
+
+    context "without a valid IIIF Manifest" do
+      before do
+        assign(:manifest, nil)
+      end
+
+      it "does not render the viewer" do
+        expect(response).not_to have_selector ".viewer[data-uri]"
       end
     end
   end


### PR DESCRIPTION
Resolves #1429 by ensuring that the Universal Viewer is not rendered for resources where the IIIF Manifest is empty or invalid