### PR TITLE
Update GeoWorks to cleanup derivatives after error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'rsolr', '~> 1.1.0'
 gem 'devise' , '~> 4.2.0'
 gem 'devise-guests', '~> 0.3'
 gem 'iiif-presentation', github: 'iiif/osullivan', branch: 'development'
-gem 'geo_works', '~> 0.1.3'
+gem 'geo_works', '~> 0.1.4'
 
 # PDF generation
 gem 'prawn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,7 +337,7 @@ GEM
       jquery-rails
     font-awesome-rails (4.7.0.2)
       railties (>= 3.2, < 5.2)
-    geo_works (0.1.3)
+    geo_works (0.1.4)
       hyrax (>= 1.0.1, < 2.0)
       jquery-ui-rails (~> 5.0.5)
       json-schema (>= 2.6.2)
@@ -724,7 +724,7 @@ GEM
     rgeo-shapefile (0.4.2)
       dbf (~> 3.0)
       rgeo (~> 0.3)
-    rgeoserver (0.10.0)
+    rgeoserver (0.10.1)
       activemodel
       activesupport
       confstruct (~> 0.2.7)
@@ -912,7 +912,7 @@ DEPENDENCIES
   factory_girl
   fcrepo_wrapper (~> 0.8.0)
   flipflop!
-  geo_works (~> 0.1.3)
+  geo_works (~> 0.1.4)
   grocer!
   honeybadger (~> 2.0)
   hydra-derivatives (= 3.1.3)


### PR DESCRIPTION
Updates GeoWorks to cleanup intermediate files after failed derivative generation.