### PR TITLE
Update GeoWorks to enable extraction of geometry from vector files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'rsolr', '~> 1.1.0'
 gem 'devise' , '~> 4.2.0'
 gem 'devise-guests', '~> 0.3'
 gem 'iiif-presentation', github: 'iiif/osullivan', branch: 'development'
-gem 'geo_works', '~> 0.1.4'
+gem 'geo_works', '~> 0.2.0'
 
 # PDF generation
 gem 'prawn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,7 +337,7 @@ GEM
       jquery-rails
     font-awesome-rails (4.7.0.2)
       railties (>= 3.2, < 5.2)
-    geo_works (0.1.4)
+    geo_works (0.2.0)
       hyrax (>= 1.0.1, < 2.0)
       jquery-ui-rails (~> 5.0.5)
       json-schema (>= 2.6.2)
@@ -912,7 +912,7 @@ DEPENDENCIES
   factory_girl
   fcrepo_wrapper (~> 0.8.0)
   flipflop!
-  geo_works (~> 0.1.4)
+  geo_works (~> 0.2.0)
   grocer!
   honeybadger (~> 2.0)
   hydra-derivatives (= 3.1.3)


### PR DESCRIPTION
Bumps GeoWorks to version 0.2.0.